### PR TITLE
Training Button Change

### DIFF
--- a/src/WinTrek/WinTrek.h
+++ b/src/WinTrek/WinTrek.h
@@ -91,6 +91,7 @@ class  WinTrekClient :
         float                   trekJoyStick[3];
         float                   fOldJoyThrottle;
         virtual void            OverrideThrottle (float fDesiredThrottle);
+		bool					bTrainingFirstClick;
 
         // igc site implementation
 

--- a/src/WinTrek/introscreen.cpp
+++ b/src/WinTrek/introscreen.cpp
@@ -862,7 +862,14 @@ public:
             // go train, because we have all the training files installed
             trekClient.SetIsLobbied(false);
             trekClient.SetIsZoneClub(false);
-            GetWindow()->screen(ScreenIDTrainScreen);
+            
+			if (trekClient.bTrainingFirstClick)
+				GetWindow()->screen(ScreenIDTrainScreen);
+			else
+			{
+				GetWindow()->ShowWebPage("http://www.freeallegiance.org/FAW/index.php/Begin_playing");
+				trekClient.bTrainingFirstClick = true;
+			}
         }
         else // wlp 2006 - go straight to lobby
         {

--- a/src/WinTrek/trekigc.cpp
+++ b/src/WinTrek/trekigc.cpp
@@ -2332,7 +2332,8 @@ WinTrekClient::WinTrekClient(void)
     m_bFilterChatsToAll(false),
     m_bFilterQuickComms(false),
 	m_bFilterUnknownChats(true), //TheBored 30-JUL-07: Filter Unknown Chat patch
-    m_dwFilterLobbyChats(3) //TheBored 25-JUN-07: Changed value to 3 (Don't Filter Lobby)
+    m_dwFilterLobbyChats(3), //TheBored 25-JUN-07: Changed value to 3 (Don't Filter Lobby)
+	bTrainingFirstClick(false)
 {
     // restore the CD Key from the registry
 


### PR DESCRIPTION
This will cause the first click of the training button to go to the new player wikilanding page. Subsequent clicks will still give you training missions.