### PR TITLE
Improved Training

### DIFF
--- a/src/Igc/igc.h
+++ b/src/Igc/igc.h
@@ -979,6 +979,7 @@ const int c_cbGamePassword = 17;
 //------------------------------------------------------------------------------
 #define IGC_STATIC_CORE_FILENAME    "static_core"
 #define IGC_ENCRYPT_CORE_FILENAME   "zone_core"
+#define IGC_TRAINING_CORE_FILENAME  "PCore013"
 
 
 const float c_fMissionBriefingCountdown = 15.0f; // seconds

--- a/src/Igc/igc.h
+++ b/src/Igc/igc.h
@@ -979,7 +979,7 @@ const int c_cbGamePassword = 17;
 //------------------------------------------------------------------------------
 #define IGC_STATIC_CORE_FILENAME    "static_core"
 #define IGC_ENCRYPT_CORE_FILENAME   "zone_core"
-#define IGC_TRAINING_CORE_FILENAME  "PCore013"
+#define IGC_TRAINING_CORE_FILENAME  "PCore012"
 
 
 const float c_fMissionBriefingCountdown = 15.0f; // seconds

--- a/src/Igc/stationIGC.cpp
+++ b/src/Igc/stationIGC.cpp
@@ -461,7 +461,7 @@ void    CstationIGC::RepairAndRefuel(IshipIGC* pship) const
         IafterburnerIGC* a = (IafterburnerIGC*)(pship->GetMountedPart(ET_Afterburner, 0));
         if (a)
             a->Deactivate();
-        else { // Prevent ship from launching wihtout essential modules - add a booster
+        else { // Add essential module
             IpartTypeIGC *ppt = GetMission()->GetPartType(174); //Hvy Booster
             if (pht->CanMount(ppt, 0)) {
                 PartData        pd;
@@ -476,7 +476,7 @@ void    CstationIGC::RepairAndRefuel(IshipIGC* pship) const
         IshieldIGC* s = (IshieldIGC*)(pship->GetMountedPart(ET_Shield, 0));
         if (s)
             s->SetFraction(1.0f);
-        else { // Prevent ship from launching wihtout essential modules - add a shield
+        else { // Add essential module
             IpartTypeIGC *ppt = GetMission()->GetPartType(40); //Sm Shield 2
             if (pht->CanMount(ppt, 0)) {
                 PartData        pd;
@@ -492,7 +492,7 @@ void    CstationIGC::RepairAndRefuel(IshipIGC* pship) const
         IafterburnerIGC*    pafter = (IafterburnerIGC*)(pship->GetMountedPart(ET_Afterburner, 0));
         if (pafter)
             pafter->Deactivate();
-        else { // Prevent ship from launching wihtout essential modules - add an afterburner
+        else { // Add essential module
             IpartTypeIGC *ppt = GetMission()->GetPartType(224); //Afterburner 3
             if (pht->CanMount(ppt, 0)) {
                 PartData        pd;

--- a/src/Igc/stationIGC.cpp
+++ b/src/Igc/stationIGC.cpp
@@ -456,25 +456,55 @@ void    CstationIGC::RepairAndRefuel(IshipIGC* pship) const
         pship->SetFraction(1.0f);
     }
 
+    const IhullTypeIGC* pht = pship->GetHullType();
     {
         IafterburnerIGC* a = (IafterburnerIGC*)(pship->GetMountedPart(ET_Afterburner, 0));
         if (a)
             a->Deactivate();
+        else { // Prevent ship from launching wihtout essential modules - add a booster
+            IpartTypeIGC *ppt = GetMission()->GetPartType(174); //Hvy Booster
+            if (pht->CanMount(ppt, 0)) {
+                PartData        pd;
+                pd.partID = 174;
+                pd.mountID = 0;
+                pd.amount = 1;
+                pship->CreateAndAddPart(&pd);
+            }
+        }
     }
     {
         IshieldIGC* s = (IshieldIGC*)(pship->GetMountedPart(ET_Shield, 0));
         if (s)
             s->SetFraction(1.0f);
+        else { // Prevent ship from launching wihtout essential modules - add a shield
+            IpartTypeIGC *ppt = GetMission()->GetPartType(40); //Sm Shield 2
+            if (pht->CanMount(ppt, 0)) {
+                PartData        pd;
+                pd.partID = 40;
+                pd.mountID = 0;
+                pd.amount = 1;
+                pship->CreateAndAddPart(&pd);
+            }
+        }
     }
 
     {
         IafterburnerIGC*    pafter = (IafterburnerIGC*)(pship->GetMountedPart(ET_Afterburner, 0));
         if (pafter)
             pafter->Deactivate();
+        else { // Prevent ship from launching wihtout essential modules - add an afterburner
+            IpartTypeIGC *ppt = GetMission()->GetPartType(224); //Afterburner 3
+            if (pht->CanMount(ppt, 0)) {
+                PartData        pd;
+                pd.partID = 224;
+                pd.mountID = 0;
+                pd.amount = 1;
+                pship->CreateAndAddPart(&pd);
+            }
+        }
     }
 
     //Give a full load of fuel and ammo
-    const IhullTypeIGC* pht = pship->GetHullType();
     if (m_myStationType.HasCapability(c_sabmReload))
     {
         short   maxAmmo = pht->GetMaxAmmo();

--- a/src/Igc/stationIGC.cpp
+++ b/src/Igc/stationIGC.cpp
@@ -456,55 +456,25 @@ void    CstationIGC::RepairAndRefuel(IshipIGC* pship) const
         pship->SetFraction(1.0f);
     }
 
-    const IhullTypeIGC* pht = pship->GetHullType();
     {
         IafterburnerIGC* a = (IafterburnerIGC*)(pship->GetMountedPart(ET_Afterburner, 0));
         if (a)
             a->Deactivate();
-        else { // Add essential module
-            IpartTypeIGC *ppt = GetMission()->GetPartType(174); //Hvy Booster
-            if (pht->CanMount(ppt, 0)) {
-                PartData        pd;
-                pd.partID = 174;
-                pd.mountID = 0;
-                pd.amount = 1;
-                pship->CreateAndAddPart(&pd);
-            }
-        }
     }
     {
         IshieldIGC* s = (IshieldIGC*)(pship->GetMountedPart(ET_Shield, 0));
         if (s)
             s->SetFraction(1.0f);
-        else { // Add essential module
-            IpartTypeIGC *ppt = GetMission()->GetPartType(40); //Sm Shield 2
-            if (pht->CanMount(ppt, 0)) {
-                PartData        pd;
-                pd.partID = 40;
-                pd.mountID = 0;
-                pd.amount = 1;
-                pship->CreateAndAddPart(&pd);
-            }
-        }
     }
 
     {
         IafterburnerIGC*    pafter = (IafterburnerIGC*)(pship->GetMountedPart(ET_Afterburner, 0));
         if (pafter)
             pafter->Deactivate();
-        else { // Add essential module
-            IpartTypeIGC *ppt = GetMission()->GetPartType(224); //Afterburner 3
-            if (pht->CanMount(ppt, 0)) {
-                PartData        pd;
-                pd.partID = 224;
-                pd.mountID = 0;
-                pd.amount = 1;
-                pship->CreateAndAddPart(&pd);
-            }
-        }
     }
 
     //Give a full load of fuel and ammo
+    const IhullTypeIGC* pht = pship->GetHullType();
     if (m_myStationType.HasCapability(c_sabmReload))
     {
         short   maxAmmo = pht->GetMaxAmmo();

--- a/src/WinTrek/WinTrek.cpp
+++ b/src/WinTrek/WinTrek.cpp
@@ -8322,7 +8322,7 @@ public:
             else
                 m_cameraControl.SetZClip(5.0f, 10000.0f);
 
-            if ((pmodelTarget == NULL) && bAnyEnemyShips && (!Training::IsTraining ()))
+            if ((pmodelTarget == NULL) && bAnyEnemyShips)
             {
                 //We have no target and there are enemy ships ... select an appropriate ship
                 const Vector&   position = pshipSource->GetPosition();

--- a/src/WinTrek/WinTrek.cpp
+++ b/src/WinTrek/WinTrek.cpp
@@ -9746,8 +9746,7 @@ public:
 
             case TK_Ripcord:
             {
-                if (!Training::IsTraining ())
-                {
+                
                     if ((trekClient.GetShip()->GetParentShip() == NULL) &&
                         trekClient.GetShip()->GetCluster())
                     {
@@ -9773,11 +9772,12 @@ public:
                                     pcluster = trekClient.GetShip()->GetCluster();
                                 assert (pcluster);
                             }
-
-                            trekClient.RequestRipcord(trekClient.GetShip(), pcluster);
+                            if (!Training::IsTraining())
+                                trekClient.RequestRipcord(trekClient.GetShip(), pcluster);
+                            else
+                                trekClient.RipcordLocal(trekClient.GetShip(), pcluster);
                         }
                     }
-                }
             }
             break;
 

--- a/src/WinTrek/WinTrek.cpp
+++ b/src/WinTrek/WinTrek.cpp
@@ -9772,10 +9772,7 @@ public:
                                     pcluster = trekClient.GetShip()->GetCluster();
                                 assert (pcluster);
                             }
-                            if (!Training::IsTraining())
-                                trekClient.RequestRipcord(trekClient.GetShip(), pcluster);
-                            else
-                                trekClient.RipcordLocal(trekClient.GetShip(), pcluster);
+                            trekClient.RequestRipcord(trekClient.GetShip(), pcluster);
                         }
                     }
             }

--- a/src/WinTrek/trekigc.cpp
+++ b/src/WinTrek/trekigc.cpp
@@ -3858,10 +3858,13 @@ bool WinTrekClient::UseRipcord(IshipIGC* pship, ImodelIGC*  pmodel)
             pship->SetCurrentTurnRate(c_axisRoll, 0.0f);
 
             pship->SetLastUpdate(lastUpdate);
-            pship->SetBB(lastUpdate, lastUpdate, 0.0f);
+            pship->SetBB(lastUpdate, lastUpdate, 0.0f); 
 
             pship->SetCluster(pcluster);
         }
+
+        PlaySoundEffect(jumpSound, pship);
+        PostText(true, "");
 
         return true;
     }

--- a/src/WinTrek/trekigc.cpp
+++ b/src/WinTrek/trekigc.cpp
@@ -3862,9 +3862,12 @@ bool WinTrekClient::UseRipcord(IshipIGC* pship, ImodelIGC*  pmodel)
 
             pship->SetCluster(pcluster);
         }
-
-        PlaySoundEffect(jumpSound, pship);
-        PostText(true, "");
+        
+        if (pship == trekClient.GetShip()) {
+            ImodelIGC* pmodel = dynamic_cast<ImodelIGC*>(pship);
+            trekClient.PlaySoundEffect(jumpSound, pmodel); //Not using trekClient. messes up system sound over time. Persistent after quiting Allegiance.
+            trekClient.PostText(true, "");
+        }
 
         return true;
     }
@@ -4105,7 +4108,9 @@ void WinTrekClient::HitWarpEvent(IshipIGC* ship, IwarpIGC* warp)
                                   (alephOrientation.GetUp() * random(2.0f, 5.0f)) +
                                   (alephOrientation.GetRight() * random(2.0f, 5.0f)) -
                                   (ship->GetRadius() + 5.0f) * backward);
-                PlaySoundEffect(jumpSound, ship);
+                if (ship == trekClient.GetShip())
+                    trekClient.PlaySoundEffect(jumpSound, dynamic_cast<ImodelIGC*>(ship));
+
                 {
                     Time    t = ship->GetLastUpdate();
                     ship->SetBB(t, t, 0.0f);

--- a/src/WinTrek/trekigc.cpp
+++ b/src/WinTrek/trekigc.cpp
@@ -4102,6 +4102,7 @@ void WinTrekClient::HitWarpEvent(IshipIGC* ship, IwarpIGC* warp)
                                   (alephOrientation.GetUp() * random(2.0f, 5.0f)) +
                                   (alephOrientation.GetRight() * random(2.0f, 5.0f)) -
                                   (ship->GetRadius() + 5.0f) * backward);
+                PlaySoundEffect(jumpSound);
                 {
                     Time    t = ship->GetLastUpdate();
                     ship->SetBB(t, t, 0.0f);

--- a/src/WinTrek/trekigc.cpp
+++ b/src/WinTrek/trekigc.cpp
@@ -4214,7 +4214,10 @@ void      WinTrekClient::ReceiveChat(IshipIGC*   pshipSender,
         else if (CHAT_INDIVIDUAL == ctRecipient
             && ((NA == oidRecipient) || (trekClient.GetShipID() == oidRecipient)))
         {
-            PlaySoundEffect(newPersonalMsgSound);
+            if (Training::IsTraining())
+                PlaySoundEffect(newChatMsgFromCommanderSound);
+            else
+                PlaySoundEffect(newPersonalMsgSound);
         }
         else
         {

--- a/src/WinTrek/trekigc.cpp
+++ b/src/WinTrek/trekigc.cpp
@@ -4102,7 +4102,7 @@ void WinTrekClient::HitWarpEvent(IshipIGC* ship, IwarpIGC* warp)
                                   (alephOrientation.GetUp() * random(2.0f, 5.0f)) +
                                   (alephOrientation.GetRight() * random(2.0f, 5.0f)) -
                                   (ship->GetRadius() + 5.0f) * backward);
-                PlaySoundEffect(jumpSound);
+                PlaySoundEffect(jumpSound, ship);
                 {
                     Time    t = ship->GetLastUpdate();
                     ship->SetBB(t, t, 0.0f);

--- a/src/WinTrek/trekigc.cpp
+++ b/src/WinTrek/trekigc.cpp
@@ -3864,8 +3864,7 @@ bool WinTrekClient::UseRipcord(IshipIGC* pship, ImodelIGC*  pmodel)
         }
         
         if (pship == trekClient.GetShip()) {
-            ImodelIGC* pmodel = dynamic_cast<ImodelIGC*>(pship);
-            trekClient.PlaySoundEffect(jumpSound, pmodel); //Not using trekClient. messes up system sound over time. Persistent after quiting Allegiance.
+            trekClient.PlaySoundEffect(jumpSound, static_cast<ImodelIGC*>(pship)); //Not using trekClient. messes up system sound over time. Persistent after quiting Allegiance.
             trekClient.PostText(true, "");
         }
 
@@ -4109,7 +4108,7 @@ void WinTrekClient::HitWarpEvent(IshipIGC* ship, IwarpIGC* warp)
                                   (alephOrientation.GetRight() * random(2.0f, 5.0f)) -
                                   (ship->GetRadius() + 5.0f) * backward);
                 if (ship == trekClient.GetShip())
-                    trekClient.PlaySoundEffect(jumpSound, dynamic_cast<ImodelIGC*>(ship));
+                    trekClient.PlaySoundEffect(jumpSound, static_cast<ImodelIGC*>(ship));
 
                 {
                     Time    t = ship->GetLastUpdate();

--- a/src/clintlib/clintlib.cpp
+++ b/src/clintlib/clintlib.cpp
@@ -2870,7 +2870,6 @@ ItreasureIGC*  BaseClient::CreateTreasureLocal(Time now, IshipIGC* pship, short 
     //stick around since it is in a cluster.
     assert(t);
     t->Release();
-
     return t;
 }
 

--- a/src/clintlib/clintlib.cpp
+++ b/src/clintlib/clintlib.cpp
@@ -2312,7 +2312,7 @@ void    BaseClient::SendChat(IshipIGC*      pshipSender,
 
         // do the right thing for training missions
         PilotType   pilotType = pship->GetPilotType();
-        if ((!m_fm.IsConnected ()) && (pilotType < c_ptPlayer) && (cid != c_cidNone))
+        if ((!m_fm.IsConnected ()) && (pilotType < c_ptPlayer) && (cid != c_cidNone) && (pship->GetSide()->GetObjectID() == m_pPlayerInfo->SideID()))
         {
             if ((cid == c_cidDefault) && (pmodelTarget != NULL))
             {
@@ -2342,7 +2342,9 @@ void    BaseClient::SendChat(IshipIGC*      pshipSender,
 
                         case c_ptWingman:
                         {
-                            if (pmodelTarget->GetSide() == pship->GetSide ())
+                            if (pmodelTarget->GetObjectType() == OT_buoy)
+                                cid = c_cidGoto;
+                            else if (pmodelTarget->GetSide() == pship->GetSide())
                                 cid = c_cidDefend;
                             else
                                 cid = c_cidAttack;

--- a/src/clintlib/clintlib.cpp
+++ b/src/clintlib/clintlib.cpp
@@ -2816,76 +2816,64 @@ void BaseClient::StationTypeChange(IstationIGC* s)
     m_pClientEventSource->OnTechTreeChanged(sid);
 }
 
-static ItreasureIGC*    CreateTreasure(BaseClient* pClient, Time now, IshipIGC* pship, IpartIGC* p, IpartTypeIGC* ppt, const Vector& position, float dv)
+ItreasureIGC*  BaseClient::CreateTreasureLocal(Time now, IshipIGC* pship, IpartIGC* p, IpartTypeIGC* ppt, const Vector& position, float dv, float lifespan)
 {
-    assert (ppt);
-    assert (dv > 1.0f);
+    assert(p);
 
-    assert (pship);
+    short amount;
+    switch (p->GetObjectType())
+    {
+    case OT_magazine:
+    case OT_dispenser:
+    case OT_pack:
+    {
+        amount = p->GetAmount();
+        if (amount == 0)
+            return NULL;
+    }
+    break;
+    default:
+        amount = 0;
+    }
+
+    return CreateTreasureLocal(now, pship, amount, ppt, position, dv, lifespan);
+}
+
+ItreasureIGC*  BaseClient::CreateTreasureLocal(Time now, IshipIGC* pship, short amount, IpartTypeIGC* ppt, const Vector& position, float dv, float lifespan)
+{
+    assert(pship);
+    assert(ppt);
+    assert(dv > 1.0f);
 
     DataTreasureIGC dt;
     dt.treasureCode = c_tcPart;
     dt.treasureID = ppt->GetObjectID();
-
-    dt.objectID = pClient->m_pCoreIGC->GenerateNewTreasureID();
-
-    dt.p0 = position; 
-
-    Vector direction;
-    {
-        //Get a nice random 3D direction
-        direction.z = random(-1.0f, 1.0f);
-
-        float   yaw = random(0.0f, pi);
-        float   cosPitch = (float)sqrt(1.0f - direction.z * direction.z);
-
-        direction.x = cos(yaw) * cosPitch;
-        direction.y = sin(yaw) * cosPitch;
-    }
-
-    float   radius = pship->GetRadius() + 10.0f;
-    dt.p0 += radius * direction;
-
-    dt.v0 = direction * dv + pship->GetVelocity();
-    switch (ppt->GetEquipmentType())
-    {
-        case ET_Magazine:
-        case ET_Dispenser:
-        {
-            assert (p);
-            dt.amount = ((IlauncherIGC*)p)->GetAmount();
-        }
-        break;
-
-        case ET_Pack:
-        {
-            DataPackTypeIGC* pdp = (DataPackTypeIGC*)(ppt->GetData());
-            dt.amount = pdp->amount;
-        }
-        break;
-
-        default:
-            dt.amount = 0;
-    }
-    dt.lifespan = 600.0f;
-
-    IclusterIGC*    pcluster = pship->GetCluster();
-    dt.clusterID = pcluster->GetObjectID();
-
+    dt.lifespan = lifespan;
+    dt.amount = amount;
     dt.createNow = false;
 
-    dt.time0 = pClient->ServerTimeFromClientTime(now);
+    dt.objectID = pship->GetMission()->GenerateNewTreasureID();
+    dt.p0 = position;
+    Vector direction = Vector::RandomDirection();
+    float   radius = pship->GetRadius() + 10.0f;
+    dt.p0 += radius * direction;
+    dt.v0 = direction * dv + pship->GetVelocity();
+    IclusterIGC*    pcluster = pship->GetCluster();
+    dt.clusterID = pcluster->GetObjectID();
+    dt.time0 = now;
 
     ItreasureIGC* t = (ItreasureIGC *)
-                      pClient->m_pCoreIGC->CreateObject(now, OT_treasure,
-                                                        &dt, sizeof(dt));
+        pship->GetMission()->CreateObject(now, OT_treasure,
+            &dt, sizeof(dt));
 
     //Note: bad form releasing a pointer before we return it but we know it will
     //stick around since it is in a cluster.
-    assert (t);
+    assert(t);
     t->Release();
+
     return t;
 }
+
 void BaseClient::KillAsteroidEvent(IasteroidIGC*            pasteroid, bool explodeF)
 {
     if (!m_fm.IsConnected())
@@ -2920,9 +2908,8 @@ void BaseClient::KillShipEvent(Time now, IshipIGC* pShip, ImodelIGC* pLauncher, 
 {
     if (!m_fm.IsConnected())
     {
-        // commented because these are causing performance problems after a while BSW 10/27/1999
-        /*
-        //Blow the parts into space
+        // Previous version commented out because these were causing performance problems after a while BSW 10/27/1999
+        // Blow the parts into space
         {
             const PartListIGC*  plist = pShip->GetParts();
             PartLinkIGC*        plink;
@@ -2930,50 +2917,38 @@ void BaseClient::KillShipEvent(Time now, IshipIGC* pShip, ImodelIGC* pLauncher, 
             {
                 IpartIGC*   p = plink->data();
 
-                CreateTreasure(this, now, pShip, p, p->GetPartType(), 
-                               p1, 100.0f);
+                if (randomInt(0, 4) == 0)
+                    CreateTreasureLocal(now, pShip, p, p->GetPartType(), p1, 100.0f);
                 p->Terminate();
             }
 
             //Treasures for ammo
             {
-                int ammo = pShip->GetAmmo();
+                short ammo = pShip->GetAmmo();
                 if (ammo > 0)
                 {
                     IpartTypeIGC*  pptAmmo = m_pCoreIGC->GetAmmoPack();
-                    assert (pptAmmo);
-                    ItreasureIGC*   t = CreateTreasure(this, now, pShip, NULL, pptAmmo, p1, 100.0f);
-                    assert (t);
-                    int a = t->GetAmount();
-                    assert (a > 0);
-                    if (ammo <= a)
-                    {
-                        t->SetAmount((short)ammo);
-                    }
+                    assert(pptAmmo);
+
+                    if (randomInt(0, 4) == 0)
+                        CreateTreasureLocal(now, pShip, ammo, pptAmmo, p1, 100.0f, 30.0f);
                     pShip->SetAmmo(0);
                 }
             }
             //Ditto for fuel
             {
-                int fuel = int(pShip->GetFuel());
+                short fuel = short(pShip->GetFuel());
                 if (fuel > 0)
                 {
                     IpartTypeIGC*  pptFuel = m_pCoreIGC->GetFuelPack();
-                    assert (pptFuel);
+                    assert(pptFuel);
 
-                    ItreasureIGC*   t = CreateTreasure(this, now, pShip, NULL, pptFuel, p1, 100.0f);
-                    assert (t);
-                    int f = t->GetAmount();
-                    assert (f > 0);
-                    if (fuel <= f)
-                    {
-                        t->SetAmount((short)fuel);
-                    }
+                    if (randomInt(0, 4) == 0)
+                        CreateTreasureLocal(now, pShip, fuel, pptFuel, p1, 100.0f, 30.0f);
+                    pShip->SetFuel(0.0f);
                 }
-                pShip->SetFuel(0.0f);
             }
         }
-        */
 
         if (pShip == m_ship->GetSourceShip())
         {

--- a/src/clintlib/clintlib.h
+++ b/src/clintlib/clintlib.h
@@ -1927,7 +1927,6 @@ public:
 
     void    BuyDefaultLoadout(IshipIGC* pship, IstationIGC* pstation, IhullTypeIGC* pht, Money* pbudget)
     {
-        debugf("BuyDefaultLoadout \n");
         assert (pship);
         assert (pship->GetChildShips()->n() == 0);
 

--- a/src/clintlib/clintlib.h
+++ b/src/clintlib/clintlib.h
@@ -1200,6 +1200,8 @@ public:
     virtual void SideDevelopmentTechChange(IsideIGC* s);
     virtual void StationTypeChange(IstationIGC* s);
     virtual void LoadoutChangeEvent(IshipIGC* pship, IpartIGC* ppart, LoadoutChange lc);
+    ItreasureIGC*  CreateTreasureLocal(Time now, IshipIGC* pship, IpartIGC* p, IpartTypeIGC* ppt, const Vector& position, float dv, float lifespan = 600.0f);
+    ItreasureIGC*  CreateTreasureLocal(Time now, IshipIGC* pship, short amount, IpartTypeIGC* ppt, const Vector& position, float dv, float lifespan = 600.0f);
 
     virtual bool Reload(IshipIGC* pship, IlauncherIGC* plauncher, EquipmentType type);
 
@@ -2003,6 +2005,8 @@ public:
             pdata->et = ppart->GetEquipmentType();
             pdata->mount = ppart->GetMountID();
         }
+        else
+            CreateTreasureLocal(m_ship->GetLastUpdate(), m_ship, ppart, ppart->GetPartType(), m_ship->GetPosition(), 20.0f);
 
         ppart->Terminate();
     }

--- a/src/training/CreateDroneAction.cpp
+++ b/src/training/CreateDroneAction.cpp
@@ -24,41 +24,71 @@ namespace Training
     //------------------------------------------------------------------------------
     // class methods
     //------------------------------------------------------------------------------
-    /* void */  CreateDroneAction::CreateDroneAction (const ZString& name, ShipID shipID, HullID hullID, SideID sideID, PilotType pilotType) : 
-    m_name (name),
-    m_shipID (shipID),
-    m_hullID (hullID),
-    m_sideID (sideID),
-    m_pilotType (pilotType),
-    m_sectorID (NA),
-    m_position (0.0f, 0.0f, 0.0f),
-    m_orientation (Vector (1.0f, 0.0f, 0.0f), Vector (0.0f, 1.0f, 0.0f)),
-    m_stationTypeID (NA),
-    m_expendableTypeID (NA)
+    /* void */  CreateDroneAction::CreateDroneAction(const ZString& name, ShipID shipID, HullID hullID, SideID sideID, PilotType pilotType, int techLevel) :
+        m_name(name),
+        m_shipID(shipID),
+        m_hullID(hullID),
+        m_sideID(sideID),
+        m_pilotType(pilotType),
+        m_techLevel(techLevel),
+        m_sectorID(NA),
+        m_position(0.0f, 0.0f, 0.0f),
+        m_orientation(Vector(1.0f, 0.0f, 0.0f), Vector(0.0f, 1.0f, 0.0f)),
+        m_stationTypeID(NA),
+        m_expendableTypeID(NA)
     {
     }
 
     //------------------------------------------------------------------------------
-    /* void */  CreateDroneAction::~CreateDroneAction (void)
+    /* void */  CreateDroneAction::~CreateDroneAction(void)
     {
     }
 
     //------------------------------------------------------------------------------
-    void        CreateDroneAction::Execute (void)
+    void        CreateDroneAction::Execute(void)
     {
         if (m_sectorID == NA)
         {
             // figure some default location
         }
-        IshipIGC*   pShip = g_pMission->CreateDrone (m_name, m_shipID, m_hullID, m_sideID, m_pilotType);
-        pShip->SetPosition (m_position);
-        pShip->SetOrientation (m_orientation);
-        pShip->SetCluster (trekClient.GetCore ()->GetCluster(m_sectorID));
+        IshipIGC*   pShip = g_pMission->CreateDrone(m_name, m_shipID, m_hullID, m_sideID, m_pilotType);
+        pShip->SetPosition(m_position);
+        pShip->SetOrientation(m_orientation);
+        pShip->SetCluster(trekClient.GetCore()->GetCluster(m_sectorID));
 
         if (m_stationTypeID != NA)
-            pShip->SetBaseData (trekClient.GetCore ()->GetStationType (m_stationTypeID));
+            pShip->SetBaseData(trekClient.GetCore()->GetStationType(m_stationTypeID));
         else if (m_expendableTypeID != NA)
-            pShip->SetBaseData (trekClient.GetCore ()->GetExpendableType (m_expendableTypeID));
+            pShip->SetBaseData(trekClient.GetCore()->GetExpendableType(m_expendableTypeID));
+
+        debugf("CreateDroneActionExecute for %s\n", (LPCSTR)m_name);
+        if (m_techLevel != 1) {
+            for (int i = 0; i < pShip->GetHullType()->GetMaxWeapons(); i++) {
+                IpartIGC* pPart = pShip->GetMountedPart(ET_Weapon, i);
+                if (pPart) {
+                    int partTypeID = pPart->GetPartType()->GetObjectID();
+                    debugf(" Weapon slot %d: %d", i, partTypeID);
+                    if (partTypeID == 33) { //33 PW Gat Gun
+                        if (m_techLevel > 1)
+                            pPart->Terminate();
+                        if (m_techLevel == 2)
+                            pShip->CreateAndAddPart(trekClient.GetCore()->GetPartType(71), i, 1); //PW Gat 2
+                        else if (m_techLevel >= 3)
+                            pShip->CreateAndAddPart(trekClient.GetCore()->GetPartType(71), i, 1); //PW Gat 2
+                    }
+                    else if (partTypeID == 200) //Nerf for rix bomber. One gun vs Bios outpost is enough
+                        if (i > 0 && m_techLevel < 1)
+                            pPart->Terminate();
+                    pPart = pShip->GetMountedPart(ET_Weapon, i);
+                    if (pPart)
+                        debugf(" changed to %d\n", pPart->GetPartType()->GetObjectID());
+                    else
+                        debugf(" removed\n");
+                }
+            }
+            trekClient.SaveLoadout(pShip);
+        }
+
     }
 
     //------------------------------------------------------------------------------

--- a/src/training/CreateDroneAction.h
+++ b/src/training/CreateDroneAction.h
@@ -25,7 +25,7 @@ namespace Training
     class CreateDroneAction : public Action
     {
         public:
-                    /* void */          CreateDroneAction (const ZString& name, ShipID shipID, HullID hullID, SideID sideID, PilotType pilotType);
+                    /* void */          CreateDroneAction (const ZString& name, ShipID shipID, HullID hullID, SideID sideID, PilotType pilotType, int techLeve = 1);
             virtual /* void */          ~CreateDroneAction (void);
             virtual void                Execute (void);
                     void                SetCreatedLocation (SectorID sectorID, const Vector& position);
@@ -44,6 +44,7 @@ namespace Training
                     Orientation         m_orientation;
                     StationTypeID       m_stationTypeID;
                     ExpendableTypeID    m_expendableTypeID;
+                    int                 m_techLevel;
     };
 
     //------------------------------------------------------------------------------

--- a/src/training/Goal.cpp
+++ b/src/training/Goal.cpp
@@ -20,7 +20,8 @@ namespace Training
     // class methods
     //------------------------------------------------------------------------------
     /* void */  Goal::Goal (Condition* pSuccessCondition) :
-    m_pSuccessCondition (pSuccessCondition)
+    m_pSuccessCondition (pSuccessCondition),
+    m_pSkipGoalCondition(NULL)
     {
     }
 
@@ -28,6 +29,7 @@ namespace Training
     /* void */  Goal::~Goal (void)
     {
         delete m_pSuccessCondition;
+        delete m_pSkipGoalCondition;
     }
 
     //------------------------------------------------------------------------------
@@ -38,7 +40,7 @@ namespace Training
         if (m_pSuccessCondition->Start () == c_GoalIncomplete)
         {
             // execute and evaluate the list conditions. If all are true, skip the goal.
-            if (m_skipGoalConditionList.Start()) {
+            if (m_pSkipGoalCondition && m_pSkipGoalCondition->Start()) {
                 debugf("Skipping goal.\n");
                 return c_GoalComplete;
             }
@@ -63,7 +65,8 @@ namespace Training
     {
         m_pSuccessCondition->Stop ();
 
-        m_skipGoalConditionList.Stop();
+        if (m_pSkipGoalCondition)
+            m_pSkipGoalCondition->Stop();
 
         // stop the start actions
         m_startActionList.Stop ();
@@ -99,7 +102,7 @@ namespace Training
     }
 
     //------------------------------------------------------------------------------
-    void        Goal::AddSkipGoalCondition(Condition* pConstraintCondition) {
-        m_skipGoalConditionList.AddCondition(pConstraintCondition);
+    void        Goal::SetSkipGoalCondition(Condition* pSkipCondition) {
+        m_pSkipGoalCondition = pSkipCondition;
     }
 }

--- a/src/training/Goal.cpp
+++ b/src/training/Goal.cpp
@@ -37,6 +37,12 @@ namespace Training
         // the goal.
         if (m_pSuccessCondition->Start () == c_GoalIncomplete)
         {
+            // execute and evaluate the list conditions. If all are true, skip the goal.
+            if (m_skipGoalConditionList.Start()) {
+                debugf("Skipping goal.\n");
+                return c_GoalComplete;
+            }
+
             // execute the start actions
             m_startActionList.Execute ();
 
@@ -56,6 +62,8 @@ namespace Training
     void        Goal::Stop (void)
     {
         m_pSuccessCondition->Stop ();
+
+        m_skipGoalConditionList.Stop();
 
         // stop the start actions
         m_startActionList.Stop ();
@@ -91,4 +99,7 @@ namespace Training
     }
 
     //------------------------------------------------------------------------------
+    void        Goal::AddSkipGoalCondition(Condition* pConstraintCondition) {
+        m_skipGoalConditionList.AddCondition(pConstraintCondition);
+    }
 }

--- a/src/training/Goal.h
+++ b/src/training/Goal.h
@@ -39,13 +39,13 @@ namespace Training
             virtual bool                Evaluate (void);
                     void                AddStartAction (Action* pStartAction);
                     void                AddConstraintCondition (Condition* pConstraintCondition);
-                    void                AddSkipGoalCondition(Condition* pConstraintCondition);
+                    void                SetSkipGoalCondition(Condition* pSkipCondition);
 
         protected:
                     Condition*          m_pSuccessCondition;
                     ActionList          m_startActionList;
                     ConditionList       m_constraintConditionList;
-                    ConditionList       m_skipGoalConditionList;
+                    Condition*          m_pSkipGoalCondition;
     };
 
     //------------------------------------------------------------------------------

--- a/src/training/Goal.h
+++ b/src/training/Goal.h
@@ -39,11 +39,13 @@ namespace Training
             virtual bool                Evaluate (void);
                     void                AddStartAction (Action* pStartAction);
                     void                AddConstraintCondition (Condition* pConstraintCondition);
+                    void                AddSkipGoalCondition(Condition* pConstraintCondition);
 
         protected:
                     Condition*          m_pSuccessCondition;
                     ActionList          m_startActionList;
                     ConditionList       m_constraintConditionList;
+                    ConditionList       m_skipGoalConditionList;
     };
 
     //------------------------------------------------------------------------------

--- a/src/training/SetStationDestroyedAction.cpp
+++ b/src/training/SetStationDestroyedAction.cpp
@@ -22,7 +22,15 @@ namespace Training
     //------------------------------------------------------------------------------
     /* void */  SetStationDestroyedAction::SetStationDestroyedAction (ImodelIGC* theStation)
     {
-       pStation = theStation;
+       pStation = static_cast<IstationIGC*>(theStation);
+       ZAssert(pStation);
+    }
+
+    //------------------------------------------------------------------------------
+    /* void */  SetStationDestroyedAction::SetStationDestroyedAction(IstationIGC* theStation)
+    {
+        pStation = theStation;
+        ZAssert(pStation);
     }
 
     //------------------------------------------------------------------------------
@@ -33,7 +41,23 @@ namespace Training
     //------------------------------------------------------------------------------
     void        SetStationDestroyedAction::Execute (void)
     {
-		if (pStation)
-			pStation->Terminate();
+        if (pStation) {
+            pStation->GetCluster()->GetClusterSite()->AddExplosion(pStation,
+                pStation->GetStationType()->HasCapability(c_sabmFlag)
+                ? c_etLargeStation
+                : c_etSmallStation);
+
+            if (pStation->GetSide() == trekClient.GetSide())
+                trekClient.PlaySoundEffect(pStation->GetStationType()->GetDestroyedSound());
+            else
+                trekClient.PlaySoundEffect(pStation->GetStationType()->GetEnemyDestroyedSound());
+
+            trekClient.PostText(true, "The " START_COLOR_STRING "%s" END_COLOR_STRING " station has been destroyed.",
+                (PCC)ConvertColorToString(pStation ? pStation->GetSide()->GetColor() : Color::White()),
+                (pStation ? pStation->GetName() : "Unknown station")
+            );
+
+            pStation->Terminate();
+        }
     }
 }

--- a/src/training/SetStationDestroyedAction.h
+++ b/src/training/SetStationDestroyedAction.h
@@ -25,11 +25,12 @@ namespace Training
     {
         public:
                     /* void */          SetStationDestroyedAction (ImodelIGC* theStation);
+                    /* void */          SetStationDestroyedAction(IstationIGC* theStation);
             virtual /* void */          ~SetStationDestroyedAction (void);
             virtual void                Execute (void);
 
         protected:
-                    ImodelIGC* pStation;
+                    IstationIGC* pStation;
     };
 
     //------------------------------------------------------------------------------

--- a/src/training/conditionlist.cpp
+++ b/src/training/conditionlist.cpp
@@ -30,7 +30,10 @@ namespace Training
     //------------------------------------------------------------------------------
     bool        ConditionList::Start (void)
     {
-        // This condition list is to be considered "true" by default.
+        // This condition list is true if not empty and all conditions are true
+        if (m_conditionList.size() < 1)
+            return false;
+
         bool    result = true;
 
         // Loop over the condition list. If any condition evaluates to false, then
@@ -57,7 +60,10 @@ namespace Training
     //------------------------------------------------------------------------------
     bool        ConditionList::Evaluate (void)
     {
-        // This condition list is to be considered "true" by default.
+        // This condition list is true if not empty and all conditions are true
+        if (m_conditionList.size() < 1)
+            return false;
+
         bool    result = true;
 
         // Loop over the condition list. If any condition evaluates to false, then

--- a/src/training/conditionlist.cpp
+++ b/src/training/conditionlist.cpp
@@ -30,10 +30,7 @@ namespace Training
     //------------------------------------------------------------------------------
     bool        ConditionList::Start (void)
     {
-        // This condition list is true if not empty and all conditions are true
-        if (m_conditionList.size() < 1)
-            return false;
-
+        // This condition list is to be considered "true" by default.
         bool    result = true;
 
         // Loop over the condition list. If any condition evaluates to false, then

--- a/src/training/messageaction.cpp
+++ b/src/training/messageaction.cpp
@@ -46,6 +46,8 @@ namespace Training
     {
         if (m_iterator == m_messageList.end ())
             m_iterator = m_messageList.begin ();
+        if (m_soundIterator == m_soundList.end())
+            m_soundIterator = m_soundList.begin();
         if (m_iterator != m_messageList.end ())
             trekClient.ReceiveChat (g_pMission->GetCommanderShip (), CHAT_INDIVIDUAL, trekClient.GetShipID (), *m_soundIterator++, *m_iterator++, c_cidNone, NA, NA, 0, false); //TheBored 06-JUL-2007: Bahdohday's edit to allow sound w/text. 
     }

--- a/src/training/mission10.cpp
+++ b/src/training/mission10.cpp
@@ -99,15 +99,20 @@ namespace Training
                 AddPartToShip(154, i, 5);
             }
         }
-        trekClient.SaveLoadout(pShipU);
-        //Add tech, so Seeker2s don't show as new treassure
+        trekClient.SaveLoadout(pShipU);*/
+        //Add tech, so equipment doesn't show as new treassure and can be got at the station
         IshipIGC*       pShip = trekClient.GetShip();
-        debugf("Pre DevelopmentTechs: %d\n", pShip->GetSide()->GetDevelopmentTechs());
-        TechTreeBitMask ttbm;
+        TechTreeBitMask ttbm = pShip->GetSide()->GetDevelopmentTechs();
+        debugf("Pre DevelopmentTechs: %s\n", (LPCSTR)trekClient.GetCore()->BitsToTechsList(ttbm));
         ttbm.ClearAll();
-        ttbm |= trekClient.GetCore()->GetPartType(154)->GetEffectTechs(); //Seeker 2 tech
+        ttbm |= trekClient.GetCore()->GetPartType(154)->GetEffectTechs();   //Seeker 2 tech
+        ttbm |= trekClient.GetCore()->GetPartType(13)->GetEffectTechs();    //Mine Pack 1 tech
+        ttbm |= trekClient.GetCore()->GetPartType(13)->GetRequiredTechs();
+        ttbm |= trekClient.GetCore()->GetPartType(174)->GetEffectTechs();   //Hvy Booster tech
+        ttbm |= trekClient.GetCore()->GetPartType(174)->GetRequiredTechs();
         pShip->GetSide()->ApplyDevelopmentTechs(ttbm);
-        debugf("Post DevelopmentTechs: %d\n", pShip->GetSide()->GetDevelopmentTechs()); //same as before, but works*/
+        ttbm = pShip->GetSide()->GetDevelopmentTechs();
+        debugf("Post DevelopmentTechs: %s\n", (LPCSTR)trekClient.GetCore()->BitsToTechsList(ttbm));
     }
 
     //------------------------------------------------------------------------------

--- a/src/training/mission10.cpp
+++ b/src/training/mission10.cpp
@@ -54,8 +54,10 @@ namespace Training
     void        Mission10::CreateUniverse(void)
     {
         LoadUniverse("training_6", 488, 1030);    // 488 = Adv. IC fighter
-                                                  //output map info
+        
         ImissionIGC*    pCore = trekClient.GetCore();
+
+        //output map info
         const ClusterListIGC *clusters = pCore->GetClusters();
         for (ClusterLinkIGC* cLink = clusters->first(); cLink != NULL; cLink = cLink->next())
         {
@@ -70,10 +72,9 @@ namespace Training
         }
 
 
-        trekClient.fGroupFire = true;             // activate all the starting weapons
+        trekClient.fGroupFire = true;           // activate all the starting weapons
 
-                                                  // put the commander ship in the station
-                                                  //ImissionIGC*    pCore = trekClient.GetCore();
+        // put the commander ship in the station
         ImodelIGC*      pStation = pCore->GetModel(OT_station, 1030);
         IshipIGC*       pCommander = pCore->GetShip(m_commanderID);
         pCommander->SetStation(static_cast<IstationIGC*> (pStation));
@@ -81,7 +82,7 @@ namespace Training
         pCommander->SetCommand(c_cmdCurrent, NULL, c_cidDoNothing);
         pCommander->SetAutopilot(false);
 
-        // Adjust loadout
+        /*// Adjust loadout
         IshipIGC*       pShipU = trekClient.GetShip();
         // destroy mounted dumbfires
         IpartIGC*       pPart = pShipU->GetMountedPart(ET_Magazine, 0);
@@ -98,6 +99,7 @@ namespace Training
                 AddPartToShip(154, i, 5);
             }
         }
+        trekClient.SaveLoadout(pShipU);
         //Add tech, so Seeker2s don't show as new treassure
         IshipIGC*       pShip = trekClient.GetShip();
         debugf("Pre DevelopmentTechs: %d\n", pShip->GetSide()->GetDevelopmentTechs());
@@ -105,7 +107,7 @@ namespace Training
         ttbm.ClearAll();
         ttbm |= trekClient.GetCore()->GetPartType(154)->GetEffectTechs(); //Seeker 2 tech
         pShip->GetSide()->ApplyDevelopmentTechs(ttbm);
-        debugf("Post DevelopmentTechs: %d\n", pShip->GetSide()->GetDevelopmentTechs()); //same as before, but works
+        debugf("Post DevelopmentTechs: %d\n", pShip->GetSide()->GetDevelopmentTechs()); //same as before, but works*/
     }
 
     //------------------------------------------------------------------------------
@@ -281,58 +283,6 @@ namespace Training
 
         return new Goal(pGoalList);
 
-
-        /*// build the goal that we'll return
-        {
-        Goal*   pGoal = new Goal(pGoalList);
-
-        // create friendly miners
-        Vector              pos = pStation->GetPosition();
-        pos.x += random(-1000.0f, 1000.0f);
-        pos.y += random(-1000.0f, 1000.0f);
-        pos.z += random(-1000.0f, 1000.0f);
-
-        ShipID              minerShipID = pMission->GenerateNewShipID();
-        CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 01", minerShipID, 438, 0, c_ptMiner);
-        pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
-        Condition*          pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
-        //pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
-
-        pos = pStation->GetPosition();
-        pos.x += random(-1000.0f, 1000.0f);
-        pos.y += random(-1000.0f, 1000.0f);
-        pos.z += random(-1000.0f, 1000.0f);
-
-        minerShipID = pMission->GenerateNewShipID();
-        pCreateDroneAction = new CreateDroneAction("Miner 02", minerShipID, 438, 0, c_ptMiner);
-        pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
-        pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
-        //pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
-
-        pos = pStation->GetPosition();
-        pos.x += random(-1000.0f, 1000.0f);
-        pos.y += random(-1000.0f, 1000.0f);
-        pos.z += random(-1000.0f, 1000.0f);
-
-        minerShipID = pMission->GenerateNewShipID();
-        pCreateDroneAction = new CreateDroneAction("Miner 03", minerShipID, 438, 0, c_ptMiner);
-        pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
-        pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
-        pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
-
-        pos = pStation->GetPosition();
-        pos.x += random(-1000.0f, 1000.0f);
-        pos.y += random(-1000.0f, 1000.0f);
-        pos.z += random(-1000.0f, 1000.0f);
-
-        minerShipID = pMission->GenerateNewShipID();
-        pCreateDroneAction = new CreateDroneAction("Miner 04", minerShipID, 438, 0, c_ptMiner);
-        pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
-        pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
-        //pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
-
-        return pGoal;
-        }*/
     }
 
     //------------------------------------------------------------------------------

--- a/src/training/mission10.cpp
+++ b/src/training/mission10.cpp
@@ -36,7 +36,8 @@ namespace Training
     //------------------------------------------------------------------------------
     SectorID    Mission10::GetStartSectorID(void)
     {
-        return 1030;
+        //return 1030; //old map
+        return 2080; //new map
     }
 
     //------------------------------------------------------------------------------
@@ -52,17 +53,51 @@ namespace Training
     //------------------------------------------------------------------------------
     void        Mission10::CreateUniverse(void)
     {
-        LoadUniverse("training_3", 488, 1030);    // a fighter 3
+        LoadUniverse("training_6", 488, 1030);    // 488 = Adv. IC fighter
+                                                  //output map info
+        ImissionIGC*    pCore = trekClient.GetCore();
+        const ClusterListIGC *clusters = pCore->GetClusters();
+        for (ClusterLinkIGC* cLink = clusters->first(); cLink != NULL; cLink = cLink->next())
+        {
+            IclusterIGC* pCluster = cLink->data();
+            debugf("Cluster %s - ObjectID: %d\n", pCluster->GetName(), pCluster->GetObjectID());
+        }
+        const StationListIGC *stations = pCore->GetStations();
+        for (StationLinkIGC* cLink = stations->first(); cLink != NULL; cLink = cLink->next())
+        {
+            IstationIGC* pStation = cLink->data();
+            debugf("Station %s - ObjectID: %d\n", pStation->GetName(), pStation->GetObjectID());
+        }
+
+
         trekClient.fGroupFire = true;             // activate all the starting weapons
 
-        // put the commander ship in the station
-        ImissionIGC*    pCore = trekClient.GetCore();
+                                                  // put the commander ship in the station
+                                                  //ImissionIGC*    pCore = trekClient.GetCore();
         ImodelIGC*      pStation = pCore->GetModel(OT_station, 1030);
         IshipIGC*       pCommander = pCore->GetShip(m_commanderID);
         pCommander->SetStation(static_cast<IstationIGC*> (pStation));
         pCommander->SetCommand(c_cmdAccepted, NULL, c_cidDoNothing);
         pCommander->SetCommand(c_cmdCurrent, NULL, c_cidDoNothing);
         pCommander->SetAutopilot(false);
+
+        // Adjust loadout
+        IshipIGC*       pShipU = trekClient.GetShip();
+        // destroy mounted dumbfires
+        IpartIGC*       pPart = pShipU->GetMountedPart(ET_Magazine, 0);
+        if (pPart)
+            pPart->Terminate();;
+        // Mount Seeker 2s
+        AddPartToShip(154, 0, 5);
+        // Change missiles in cargo for Seeker 2s
+        for (int i = -1; i >= -c_maxCargo; i--) {
+            pPart = pShipU->GetMountedPart(NA, i);
+            if (pPart->GetEquipmentType() == ET_Magazine)
+            {
+                pPart->Terminate();
+                AddPartToShip(154, i, 5);
+            }
+        }
     }
 
     //------------------------------------------------------------------------------
@@ -73,13 +108,44 @@ namespace Training
 
         GoalList*   pGoalList = new GoalList;
 
-        // wait .1 seconds, so stuff is initialized
-        pGoalList->AddGoal(new Goal(new ElapsedTimeCondition(0.1f)));
+        ImissionIGC*        pMission = trekClient.GetCore();
+        ImodelIGC*          pHomeStation = pMission->GetModel(OT_station, 2080);
+
+        // create friendly miner
+        {
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(0.1f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = Vector(0.0f, 2500.0f, 100.0f); //create forward to draw aggro
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 01", minerID, 438, 0, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            pGoalList->AddGoal(pGoal);
+        }
 
         // play the introductory audio and change camera
         {
             Goal*   pGoal = CreatePlaySoundGoal(salCommenceScanSound);
-            pGoal->AddStartAction(new SetDisplayModeAction(TrekWindow::cmCockpit));
+            pGoal->AddStartAction(new SetDisplayModeAction(TrekWindow::cmCockpit)); //this needs some delay prior, so stuff is initialized
+            pGoalList->AddGoal(pGoal);
+        }
+
+
+        // create friendly miner
+        {
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(0.2f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = pHomeStation->GetPosition();
+            pos.x += -250.0f; //simulate undock
+            pos.y += 200.0f;
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 02", minerID, 438, 0, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+            pGoal->AddStartAction(pCreateDroneAction);
+
             pGoalList->AddGoal(pGoal);
         }
 
@@ -95,6 +161,21 @@ namespace Training
             pGoalList->AddGoal(pGoal);
         }
 
+        // create friendly miner
+        {
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(0.2f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = pHomeStation->GetPosition();
+            pos.x += 250.0f; //simulate undock
+            pos.y += -200.0f;
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 03", minerID, 438, 0, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            pGoalList->AddGoal(pGoal);
+        }
         // wait half  second
         pGoalList->AddGoal(new Goal(new ElapsedTimeCondition(0.5f)));
 
@@ -102,84 +183,147 @@ namespace Training
         // DEFEND THE MINERS! This simulation is over when you die.
         pGoalList->AddGoal(CreatePlaySoundGoal(tm_6_03Sound));
 
-        // wait two more seconds
-        pGoalList->AddGoal(new Goal(new ElapsedTimeCondition(2.0f)));
-
-        // need this
-        ImissionIGC*        pMission = trekClient.GetCore();
-        ImodelIGC*          pStation = pMission->GetModel(OT_station, 1030);
-
-        // wait for player to be dead
+        // create enemy carrier
         {
-            Goal*               pGoal = new Goal(new FalseCondition);
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(1.0f));
 
-            // create enemy ships
-            ShipID              enemyShipID = pMission->GenerateNewShipID();
-            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Enemy Support", enemyShipID, 310, 1, c_ptWingman);
-            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4275.0f, 855.0f));
-            Condition*          pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (enemyShipID));
-            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
+            ShipID          carrierID = pMission->GenerateNewShipID();
+            Vector          pos = Vector(3560.0f, 4880.0f, 850.0f); //Near Neptune aleph
 
-            enemyShipID = pMission->GenerateNewShipID();
-            pCreateDroneAction = new CreateDroneAction("Enemy Fighter", enemyShipID, 315, 1, c_ptWingman);
-            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4175.0f, 855.0f));
-            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (enemyShipID));
-            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Enemy Carrier", carrierID, 325, 1, c_ptCarrier);
+            pCreateDroneAction->SetCreatedLocation(2081, pos); //Mars sector 2081
+            pGoal->AddStartAction(pCreateDroneAction);
 
             pGoalList->AddGoal(pGoal);
         }
 
-        // build the goal that we'll return
+        // wait one more second
+        pGoalList->AddGoal(new Goal(new ElapsedTimeCondition(1.0f)));
+
+        //create enemy ids to reuse
+        ShipID              enemyScoutID = pMission->GenerateNewShipID();
+        ShipID              enemyFighterID = pMission->GenerateNewShipID();
+        //spawn enemies
         {
-            Goal*   pGoal = new Goal(pGoalList);
+            Goal*           pGoal = new Goal(new ElapsedTimeCondition(8.0f));
 
-            // create friendly miners
-            Vector              pos = pStation->GetPosition();
-            pos.x += random(-1000.0f, 1000.0f);
-            pos.y += random(-1000.0f, 1000.0f);
-            pos.z += random(-1000.0f, 1000.0f);
+            CreateDroneAction*  pCreateEnemyScoutAction = new CreateDroneAction("Enemy Support", enemyScoutID, 310, 1, c_ptWingman); //310 == Bios Scout
+            pCreateEnemyScoutAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4275.0f, 855.0f));
+            CreateDroneAction* pCreateEnemyFighterAction = new CreateDroneAction("Enemy Fighter", enemyFighterID, 315, 1, c_ptWingman); //315 == Bios Fighter
+            pCreateEnemyFighterAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4175.0f, 855.0f));
 
-            ShipID              minerShipID = pMission->GenerateNewShipID();
-            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 01", minerShipID, 436, 0, c_ptMiner);
-            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
-            Condition*          pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
-            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
+            pGoal->AddStartAction(pCreateEnemyScoutAction);
+            pGoal->AddStartAction(pCreateEnemyFighterAction);
 
-            pos = pStation->GetPosition();
-            pos.x += random(-1000.0f, 1000.0f);
-            pos.y += random(-1000.0f, 1000.0f);
-            pos.z += random(-1000.0f, 1000.0f);
-
-            minerShipID = pMission->GenerateNewShipID();
-            pCreateDroneAction = new CreateDroneAction("Miner 02", minerShipID, 436, 0, c_ptMiner);
-            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
-            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
-            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
-
-            pos = pStation->GetPosition();
-            pos.x += random(-1000.0f, 1000.0f);
-            pos.y += random(-1000.0f, 1000.0f);
-            pos.z += random(-1000.0f, 1000.0f);
-
-            minerShipID = pMission->GenerateNewShipID();
-            pCreateDroneAction = new CreateDroneAction("Miner 03", minerShipID, 436, 0, c_ptMiner);
-            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
-            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
-            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
-
-            pos = pStation->GetPosition();
-            pos.x += random(-1000.0f, 1000.0f);
-            pos.y += random(-1000.0f, 1000.0f);
-            pos.z += random(-1000.0f, 1000.0f);
-
-            minerShipID = pMission->GenerateNewShipID();
-            pCreateDroneAction = new CreateDroneAction("Miner 04", minerShipID, 436, 0, c_ptMiner);
-            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
-            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
-            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
-
-            return pGoal;
+            pGoalList->AddGoal(pGoal);
         }
+
+        // create enemy miners
+        {
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(1.0f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = Vector(3080.0f, -440.0f, -700.0f); //near mid he-3
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Enemy Miner 01", minerID, 338, 1, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(2082, pos); //sector "Enemy"
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            minerID = pMission->GenerateNewShipID();
+            pos = Vector(-1760.0f, -3240.0f, -700.0f); //near lower left he-3
+            pCreateDroneAction = new CreateDroneAction("Enemy Miner 02", minerID, 338, 1, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(2082, pos); //sector "Enemy"
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            pGoalList->AddGoal(pGoal);
+        }
+        // create friendly miner
+        {
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(1.0f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = pHomeStation->GetPosition();
+            pos.x += -250.0f; //simulate undock
+            pos.y += 200.0f;
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 04", minerID, 437, 0, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            pGoalList->AddGoal(pGoal);
+        }
+
+        //respawn the enmies if destroyed (or not yet created)
+        {
+            Goal*               pGoal = new Goal(new FalseCondition); //will never evaluate as true - wait for player to be dead
+
+                                                                      //can't reuse old actions, or clean-up will fail
+            CreateDroneAction*  pCreateEnemyScoutAction = new CreateDroneAction("Enemy Support", enemyScoutID, 310, 1, c_ptWingman); //310 == Bios Scout
+            pCreateEnemyScoutAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4275.0f, 855.0f));
+            CreateDroneAction* pCreateEnemyFighterAction = new CreateDroneAction("Enemy Fighter", enemyFighterID, 315, 1, c_ptWingman); //315 == Bios Fighter
+            pCreateEnemyFighterAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4175.0f, 855.0f));
+
+            Condition*          pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (enemyScoutID));
+            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateEnemyScoutAction));
+            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (enemyFighterID));
+            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateEnemyFighterAction));
+
+            pGoalList->AddGoal(pGoal);
+        }
+
+        return new Goal(pGoalList);
+
+        /*// build the goal that we'll return
+        {
+        Goal*   pGoal = new Goal(pGoalList);
+
+        // create friendly miners
+        Vector              pos = pStation->GetPosition();
+        pos.x += random(-1000.0f, 1000.0f);
+        pos.y += random(-1000.0f, 1000.0f);
+        pos.z += random(-1000.0f, 1000.0f);
+
+        ShipID              minerShipID = pMission->GenerateNewShipID();
+        CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 01", minerShipID, 438, 0, c_ptMiner);
+        pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+        Condition*          pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
+        //pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
+
+        pos = pStation->GetPosition();
+        pos.x += random(-1000.0f, 1000.0f);
+        pos.y += random(-1000.0f, 1000.0f);
+        pos.z += random(-1000.0f, 1000.0f);
+
+        minerShipID = pMission->GenerateNewShipID();
+        pCreateDroneAction = new CreateDroneAction("Miner 02", minerShipID, 438, 0, c_ptMiner);
+        pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+        pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
+        //pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
+
+        pos = pStation->GetPosition();
+        pos.x += random(-1000.0f, 1000.0f);
+        pos.y += random(-1000.0f, 1000.0f);
+        pos.z += random(-1000.0f, 1000.0f);
+
+        minerShipID = pMission->GenerateNewShipID();
+        pCreateDroneAction = new CreateDroneAction("Miner 03", minerShipID, 438, 0, c_ptMiner);
+        pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+        pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
+        pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
+
+        pos = pStation->GetPosition();
+        pos.x += random(-1000.0f, 1000.0f);
+        pos.y += random(-1000.0f, 1000.0f);
+        pos.z += random(-1000.0f, 1000.0f);
+
+        minerShipID = pMission->GenerateNewShipID();
+        pCreateDroneAction = new CreateDroneAction("Miner 04", minerShipID, 438, 0, c_ptMiner);
+        pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+        pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (minerShipID));
+        //pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateDroneAction));
+
+        return pGoal;
+        }*/
     }
 
     //------------------------------------------------------------------------------

--- a/src/training/mission10.cpp
+++ b/src/training/mission10.cpp
@@ -101,17 +101,14 @@ namespace Training
         }
         trekClient.SaveLoadout(pShipU);*/
         //Add tech, so equipment doesn't show as new treassure and can be got at the station
-        IshipIGC*       pShip = trekClient.GetShip();
-        TechTreeBitMask ttbm = pShip->GetSide()->GetDevelopmentTechs();
+        TechTreeBitMask ttbm = trekClient.GetSide()->GetDevelopmentTechs();
         debugf("Pre DevelopmentTechs: %s\n", (LPCSTR)trekClient.GetCore()->BitsToTechsList(ttbm));
-        ttbm.ClearAll();
         ttbm |= trekClient.GetCore()->GetPartType(154)->GetEffectTechs();   //Seeker 2 tech
         ttbm |= trekClient.GetCore()->GetPartType(13)->GetEffectTechs();    //Mine Pack 1 tech
         ttbm |= trekClient.GetCore()->GetPartType(13)->GetRequiredTechs();
         ttbm |= trekClient.GetCore()->GetPartType(174)->GetEffectTechs();   //Hvy Booster tech
         ttbm |= trekClient.GetCore()->GetPartType(174)->GetRequiredTechs();
-        pShip->GetSide()->ApplyDevelopmentTechs(ttbm);
-        ttbm = pShip->GetSide()->GetDevelopmentTechs();
+        trekClient.GetSide()->SetDevelopmentTechs(ttbm);
         debugf("Post DevelopmentTechs: %s\n", (LPCSTR)trekClient.GetCore()->BitsToTechsList(ttbm));
     }
 
@@ -148,13 +145,13 @@ namespace Training
         }
 
 
-        // create friendly miner
+        // create friendly miner 02
         {
             Goal*	pGoal = new Goal(new ElapsedTimeCondition(0.2f));
 
             ShipID          minerID = pMission->GenerateNewShipID();
             Vector          pos = pHomeStation->GetPosition();
-            pos.x += -250.0f; //simulate undock
+            pos.x += 250.0f; //simulate undock
             pos.y += 200.0f;
 
             CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 02", minerID, 438, 0, c_ptMiner);
@@ -176,13 +173,13 @@ namespace Training
             pGoalList->AddGoal(pGoal);
         }
 
-        // create friendly miner
+        // create friendly miner 03
         {
             Goal*	pGoal = new Goal(new ElapsedTimeCondition(0.2f));
 
             ShipID          minerID = pMission->GenerateNewShipID();
             Vector          pos = pHomeStation->GetPosition();
-            pos.x += 250.0f; //simulate undock
+            pos.x += -250.0f; //simulate undock
             pos.y += -200.0f;
 
             CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 03", minerID, 438, 0, c_ptMiner);
@@ -252,13 +249,13 @@ namespace Training
 
             pGoalList->AddGoal(pGoal);
         }
-        // create friendly miner
+        // create friendly miner 04
         {
             Goal*	pGoal = new Goal(new ElapsedTimeCondition(1.0f));
 
             ShipID          minerID = pMission->GenerateNewShipID();
             Vector          pos = pHomeStation->GetPosition();
-            pos.x += -250.0f; //simulate undock
+            pos.x += 250.0f; //simulate undock
             pos.y += 200.0f;
 
             CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 04", minerID, 437, 0, c_ptMiner);

--- a/src/training/mission10.cpp
+++ b/src/training/mission10.cpp
@@ -98,6 +98,14 @@ namespace Training
                 AddPartToShip(154, i, 5);
             }
         }
+        //Add tech, so Seeker2s don't show as new treassure
+        IshipIGC*       pShip = trekClient.GetShip();
+        debugf("Pre DevelopmentTechs: %d\n", pShip->GetSide()->GetDevelopmentTechs());
+        TechTreeBitMask ttbm;
+        ttbm.ClearAll();
+        ttbm |= trekClient.GetCore()->GetPartType(154)->GetEffectTechs(); //Seeker 2 tech
+        pShip->GetSide()->ApplyDevelopmentTechs(ttbm);
+        debugf("Post DevelopmentTechs: %d\n", pShip->GetSide()->GetDevelopmentTechs()); //same as before, but works
     }
 
     //------------------------------------------------------------------------------
@@ -272,6 +280,7 @@ namespace Training
         }
 
         return new Goal(pGoalList);
+
 
         /*// build the goal that we'll return
         {

--- a/src/training/mission6.cpp
+++ b/src/training/mission6.cpp
@@ -90,14 +90,13 @@ namespace Training
         }
         trekClient.SaveLoadout(pShipU);
         //Add tech, so equipment doesn't show as new treassure and can be got at the station
-        IshipIGC*       pShip = trekClient.GetShip();
-        TechTreeBitMask ttbm = pShip->GetSide()->GetDevelopmentTechs();
+        TechTreeBitMask ttbm = trekClient.GetSide()->GetDevelopmentTechs();
         ttbm |= trekClient.GetCore()->GetPartType(154)->GetEffectTechs();   //Seeker 2 tech
         ttbm |= trekClient.GetCore()->GetPartType(13)->GetEffectTechs();    //Mine Pack 1 tech
         ttbm |= trekClient.GetCore()->GetPartType(13)->GetRequiredTechs();
         ttbm |= trekClient.GetCore()->GetPartType(174)->GetEffectTechs();   //Hvy Booster tech
         ttbm |= trekClient.GetCore()->GetPartType(174)->GetRequiredTechs();
-        pShip->GetSide()->SetDevelopmentTechs(ttbm);
+        trekClient.GetSide()->SetDevelopmentTechs(ttbm);
     }
 
     //------------------------------------------------------------------------------
@@ -113,7 +112,7 @@ namespace Training
         // play the introductory audio
         pGoalList->AddGoal (CreatePlaySoundGoal (salCommenceScanSound));
 
-        // create friendly miner
+        // create friendly miner 01
         {
             Goal*	pGoal = new Goal(new ElapsedTimeCondition(0.5f));
 
@@ -132,13 +131,13 @@ namespace Training
 		// outpost here in case you need to replenish yourself.
         pGoalList->AddGoal (CreatePlaySoundGoal (tm_6_01Sound));
 
-        // create friendly miner, wait two more seconds in cockpit
+        // create friendly miner 02, wait two more seconds in cockpit
         {
             Goal*	pGoal = new Goal(new ElapsedTimeCondition(2.0f));
 
             ShipID          minerID = pMission->GenerateNewShipID();
             Vector          pos = pHomeStation->GetPosition();
-            pos.x += -250.0f; //simulate undock
+            pos.x += 250.0f; //simulate undock
             pos.y += 200.0f;
 
             CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 02", minerID, 438, 0, c_ptMiner);
@@ -166,7 +165,7 @@ namespace Training
 
             ShipID          minerID = pMission->GenerateNewShipID();
             Vector          pos = pHomeStation->GetPosition();
-            pos.x += 250.0f; //simulate undock
+            pos.x += -250.0f; //simulate undock
             pos.y += -200.0f;
 
             CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 03", minerID, 438, 0, c_ptMiner);
@@ -243,7 +242,7 @@ namespace Training
 
             ShipID          minerID = pMission->GenerateNewShipID();
             Vector          pos = pHomeStation->GetPosition();
-            pos.x += -250.0f; //simulate undock
+            pos.x += 250.0f; //simulate undock
             pos.y += 200.0f;
 
             CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 04", minerID, 437, 0, c_ptMiner);

--- a/src/training/mission6.cpp
+++ b/src/training/mission6.cpp
@@ -89,12 +89,15 @@ namespace Training
             }
         }
         trekClient.SaveLoadout(pShipU);
-        //Add tech, so Seeker2s don't show as new treassure
+        //Add tech, so equipment doesn't show as new treassure and can be got at the station
         IshipIGC*       pShip = trekClient.GetShip();
-        TechTreeBitMask ttbm;
-        ttbm.ClearAll();
-        ttbm |= trekClient.GetCore()->GetPartType(154)->GetEffectTechs(); //Seeker 2 tech
-        pShip->GetSide()->ApplyDevelopmentTechs(ttbm);
+        TechTreeBitMask ttbm = pShip->GetSide()->GetDevelopmentTechs();
+        ttbm |= trekClient.GetCore()->GetPartType(154)->GetEffectTechs();   //Seeker 2 tech
+        ttbm |= trekClient.GetCore()->GetPartType(13)->GetEffectTechs();    //Mine Pack 1 tech
+        ttbm |= trekClient.GetCore()->GetPartType(13)->GetRequiredTechs();
+        ttbm |= trekClient.GetCore()->GetPartType(174)->GetEffectTechs();   //Hvy Booster tech
+        ttbm |= trekClient.GetCore()->GetPartType(174)->GetRequiredTechs();
+        pShip->GetSide()->SetDevelopmentTechs(ttbm);
     }
 
     //------------------------------------------------------------------------------

--- a/src/training/mission6.cpp
+++ b/src/training/mission6.cpp
@@ -41,7 +41,7 @@ namespace Training
     //------------------------------------------------------------------------------
     SectorID    Mission6::GetStartSectorID (void)
     {
-        return 1030;
+        return 2080; //new map
     }
 
     //------------------------------------------------------------------------------
@@ -57,7 +57,7 @@ namespace Training
     //------------------------------------------------------------------------------
     void        Mission6::CreateUniverse (void)
     {
-        LoadUniverse ("training_3", 488, 1030);    // a fighter 3
+        LoadUniverse("training_6", 488, 1030);    // 488 = Adv. IC fighter
 
         // activate all the starting weapons
         trekClient.fGroupFire = true;
@@ -70,29 +70,81 @@ namespace Training
         pCommander->SetCommand (c_cmdAccepted, NULL, c_cidDoNothing);
         pCommander->SetCommand (c_cmdCurrent, NULL, c_cidDoNothing);
         pCommander->SetAutopilot (false);
+
+        // Adjust loadout
+        IshipIGC*       pShipU = trekClient.GetShip();
+        // destroy mounted dumbfires
+        IpartIGC*       pPart = pShipU->GetMountedPart(ET_Magazine, 0);
+        if (pPart)
+            pPart->Terminate();;
+        // Mount Seeker 2s
+        AddPartToShip(154, 0, 5);
+        // Change missiles in cargo for Seeker 2s
+        for (int i = -1; i >= -c_maxCargo; i--) {
+            pPart = pShipU->GetMountedPart(NA, i);
+            if (pPart->GetEquipmentType() == ET_Magazine)
+            {
+                pPart->Terminate();
+                AddPartToShip(154, i, 5);
+            }
+        }
+        trekClient.SaveLoadout(pShipU);
+        //Add tech, so Seeker2s don't show as new treassure
+        IshipIGC*       pShip = trekClient.GetShip();
+        TechTreeBitMask ttbm;
+        ttbm.ClearAll();
+        ttbm |= trekClient.GetCore()->GetPartType(154)->GetEffectTechs(); //Seeker 2 tech
+        pShip->GetSide()->ApplyDevelopmentTechs(ttbm);
     }
 
     //------------------------------------------------------------------------------
     Condition*  Mission6::CreateMission (void)
     {
+        m_commandViewEnabled = true;
+
         GoalList*   pGoalList = new GoalList;
+
+        ImissionIGC*        pMission = trekClient.GetCore();
+        ImodelIGC*          pHomeStation = pMission->GetModel(OT_station, 2080);
 
         // play the introductory audio
         pGoalList->AddGoal (CreatePlaySoundGoal (salCommenceScanSound));
 
-        // wait half  second
-        pGoalList->AddGoal (new Goal (new ElapsedTimeCondition (0.5f)));
+        // create friendly miner
+        {
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(0.5f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = Vector(0.0f, 2500.0f, 100.0f); //create forward to draw aggro
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 01", minerID, 438, 0, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            pGoalList->AddGoal(pGoal);
+        }
 
 		// tm_6_01
 		// Okay, Cadet, here's your Advanced Fighter. There's a base 
 		// outpost here in case you need to replenish yourself.
         pGoalList->AddGoal (CreatePlaySoundGoal (tm_6_01Sound));
 
-        // wait two more seconds in cockpit
+        // create friendly miner, wait two more seconds in cockpit
         {
-	        Goal*   pGoal = new Goal(new ElapsedTimeCondition(2.0f));
-	        pGoal->AddStartAction(new SetDisplayModeAction(TrekWindow::cmCockpit));
-	        pGoalList->AddGoal(pGoal);
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(2.0f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = pHomeStation->GetPosition();
+            pos.x += -250.0f; //simulate undock
+            pos.y += 200.0f;
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 02", minerID, 438, 0, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            pGoal->AddStartAction(new SetDisplayModeAction(TrekWindow::cmCockpit));
+
+            pGoalList->AddGoal(pGoal);
         }
 
 		// tm_6_02
@@ -105,6 +157,22 @@ namespace Training
             pGoalList->AddGoal (pGoal);
         }
 
+        // create friendly miner 03
+        {
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(0.2f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = pHomeStation->GetPosition();
+            pos.x += 250.0f; //simulate undock
+            pos.y += -200.0f;
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 03", minerID, 438, 0, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            pGoalList->AddGoal(pGoal);
+        }
+
         // wait half  second
         pGoalList->AddGoal (new Goal (new ElapsedTimeCondition (0.5f)));
 
@@ -112,84 +180,96 @@ namespace Training
 		// DEFEND THE MINERS! This simulation is over when you die.
         pGoalList->AddGoal (CreatePlaySoundGoal (tm_6_03Sound));
 
-        // wait two more seconds
-        pGoalList->AddGoal (new Goal (new ElapsedTimeCondition (2.0f)));
-
-        // need this
-        ImissionIGC*        pMission = trekClient.GetCore();
-        ImodelIGC*          pStation = pMission->GetModel (OT_station, 1030);
-
-        // wait for player to be dead
+        // create enemy carrier
         {
-            Goal*               pGoal = new Goal (new FalseCondition);
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(1.0f));
 
-            // create enemy ships
-            ShipID              enemyShipID = pMission->GenerateNewShipID ();
-            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction ("Enemy Support", enemyShipID, 310, 1, c_ptWingman);
-            pCreateDroneAction->SetCreatedLocation (GetStartSectorID (), Vector (3800.0f, 4275.0f, 855.0f));
-            Condition*          pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2 (OT_ship, static_cast<ObjectID> (enemyShipID));
-            pGoal->AddConstraintCondition (new ConditionalAction (pShipIsDestroyedcondition, pCreateDroneAction));
+            ShipID          carrierID = pMission->GenerateNewShipID();
+            Vector          pos = Vector(3560.0f, 4880.0f, 850.0f); //Near Neptune aleph
 
-            enemyShipID = pMission->GenerateNewShipID ();
-            pCreateDroneAction = new CreateDroneAction ("Enemy Fighter", enemyShipID, 315, 1, c_ptWingman);
-            pCreateDroneAction->SetCreatedLocation (GetStartSectorID (), Vector (3800.0f, 4175.0f, 855.0f));
-            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2 (OT_ship, static_cast<ObjectID> (enemyShipID));
-            pGoal->AddConstraintCondition (new ConditionalAction (pShipIsDestroyedcondition, pCreateDroneAction));
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Enemy Carrier", carrierID, 325, 1, c_ptCarrier);
+            pCreateDroneAction->SetCreatedLocation(2081, pos); //Mars sector 2081
+            pGoal->AddStartAction(pCreateDroneAction);
 
-            pGoalList->AddGoal (pGoal);
+            pGoalList->AddGoal(pGoal);
         }
 
-        // build the goal that we'll return
+        // wait one more second
+        pGoalList->AddGoal(new Goal(new ElapsedTimeCondition(1.0f)));
+
+        //create enemy ids to reuse
+        ShipID              enemyScoutID = pMission->GenerateNewShipID();
+        ShipID              enemyFighterID = pMission->GenerateNewShipID();
+        //spawn enemies
         {
-            Goal*   pGoal = new Goal (pGoalList);
+            Goal*           pGoal = new Goal(new ElapsedTimeCondition(8.0f));
 
-            // create friendly miners
-            Vector              pos = pStation->GetPosition ();
-            pos.x += random(-1000.0f, 1000.0f);
-            pos.y += random(-1000.0f, 1000.0f);
-            pos.z += random(-1000.0f, 1000.0f);
+            CreateDroneAction*  pCreateEnemyScoutAction = new CreateDroneAction("Enemy Support", enemyScoutID, 310, 1, c_ptWingman); //310 == Bios Scout
+            pCreateEnemyScoutAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4275.0f, 855.0f));
+            CreateDroneAction* pCreateEnemyFighterAction = new CreateDroneAction("Enemy Fighter", enemyFighterID, 315, 1, c_ptWingman); //315 == Bios Fighter
+            pCreateEnemyFighterAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4175.0f, 855.0f));
 
-            ShipID              minerShipID = pMission->GenerateNewShipID ();
-            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction ("Miner 01", minerShipID, 436, 0, c_ptMiner);
-            pCreateDroneAction->SetCreatedLocation (GetStartSectorID (), pos);
-            Condition*          pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2 (OT_ship, static_cast<ObjectID> (minerShipID));
-            pGoal->AddConstraintCondition (new ConditionalAction (pShipIsDestroyedcondition, pCreateDroneAction));
+            pGoal->AddStartAction(pCreateEnemyScoutAction);
+            pGoal->AddStartAction(pCreateEnemyFighterAction);
 
-            pos = pStation->GetPosition ();
-            pos.x += random(-1000.0f, 1000.0f);
-            pos.y += random(-1000.0f, 1000.0f);
-            pos.z += random(-1000.0f, 1000.0f);
-
-            minerShipID = pMission->GenerateNewShipID ();
-            pCreateDroneAction = new CreateDroneAction ("Miner 02", minerShipID, 436, 0, c_ptMiner);
-            pCreateDroneAction->SetCreatedLocation (GetStartSectorID (), pos);
-            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2 (OT_ship, static_cast<ObjectID> (minerShipID));
-            pGoal->AddConstraintCondition (new ConditionalAction (pShipIsDestroyedcondition, pCreateDroneAction));
-
-            pos = pStation->GetPosition ();
-            pos.x += random(-1000.0f, 1000.0f);
-            pos.y += random(-1000.0f, 1000.0f);
-            pos.z += random(-1000.0f, 1000.0f);
-
-            minerShipID = pMission->GenerateNewShipID ();
-            pCreateDroneAction = new CreateDroneAction ("Miner 03", minerShipID, 436, 0, c_ptMiner);
-            pCreateDroneAction->SetCreatedLocation (GetStartSectorID (), pos);
-            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2 (OT_ship, static_cast<ObjectID> (minerShipID));
-            pGoal->AddConstraintCondition (new ConditionalAction (pShipIsDestroyedcondition, pCreateDroneAction));
-
-            pos = pStation->GetPosition ();
-            pos.x += random(-1000.0f, 1000.0f);
-            pos.y += random(-1000.0f, 1000.0f);
-            pos.z += random(-1000.0f, 1000.0f);
-
-            minerShipID = pMission->GenerateNewShipID ();
-            pCreateDroneAction = new CreateDroneAction ("Miner 04", minerShipID, 436, 0, c_ptMiner);
-            pCreateDroneAction->SetCreatedLocation (GetStartSectorID (), pos);
-            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2 (OT_ship, static_cast<ObjectID> (minerShipID));
-            pGoal->AddConstraintCondition (new ConditionalAction (pShipIsDestroyedcondition, pCreateDroneAction));
-
-            return pGoal;
+            pGoalList->AddGoal(pGoal);
         }
+
+        // create enemy miners
+        {
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(1.0f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = Vector(3080.0f, -440.0f, -700.0f); //near mid he-3
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Enemy Miner 01", minerID, 338, 1, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(2082, pos); //sector "Enemy"
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            minerID = pMission->GenerateNewShipID();
+            pos = Vector(-1760.0f, -3240.0f, -700.0f); //near lower left he-3
+            pCreateDroneAction = new CreateDroneAction("Enemy Miner 02", minerID, 338, 1, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(2082, pos); //sector "Enemy"
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            pGoalList->AddGoal(pGoal);
+        }
+        // create friendly miner 04
+        {
+            Goal*	pGoal = new Goal(new ElapsedTimeCondition(1.0f));
+
+            ShipID          minerID = pMission->GenerateNewShipID();
+            Vector          pos = pHomeStation->GetPosition();
+            pos.x += -250.0f; //simulate undock
+            pos.y += 200.0f;
+
+            CreateDroneAction*  pCreateDroneAction = new CreateDroneAction("Miner 04", minerID, 437, 0, c_ptMiner);
+            pCreateDroneAction->SetCreatedLocation(GetStartSectorID(), pos);
+            pGoal->AddStartAction(pCreateDroneAction);
+
+            pGoalList->AddGoal(pGoal);
+        }
+
+        //respawn the enmies if destroyed (or not yet created)
+        {
+            Goal*               pGoal = new Goal(new FalseCondition); //will never evaluate as true - wait for player to be dead
+
+                                                                      //can't reuse old actions, or clean-up will fail
+            CreateDroneAction*  pCreateEnemyScoutAction = new CreateDroneAction("Enemy Support", enemyScoutID, 310, 1, c_ptWingman); //310 == Bios Scout
+            pCreateEnemyScoutAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4275.0f, 855.0f));
+            CreateDroneAction* pCreateEnemyFighterAction = new CreateDroneAction("Enemy Fighter", enemyFighterID, 315, 1, c_ptWingman); //315 == Bios Fighter
+            pCreateEnemyFighterAction->SetCreatedLocation(GetStartSectorID(), Vector(3800.0f, 4175.0f, 855.0f));
+
+            Condition*          pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (enemyScoutID));
+            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateEnemyScoutAction));
+            pShipIsDestroyedcondition = new GetShipIsDestroyedCondition2(OT_ship, static_cast<ObjectID> (enemyFighterID));
+            pGoal->AddConstraintCondition(new ConditionalAction(pShipIsDestroyedcondition, pCreateEnemyFighterAction));
+
+            pGoalList->AddGoal(pGoal);
+        }
+
+        return new Goal(pGoalList);
+
     }
 
     //------------------------------------------------------------------------------

--- a/src/training/mission8.h
+++ b/src/training/mission8.h
@@ -40,15 +40,10 @@ namespace Training
                     Goal*                   CreateGoal01 (void);
                     Goal*                   CreateGoal02 (void);
                     Goal*                   CreateGoal03 (void);
-                    Goal*                   CreateGoal04 (void);
-                    Goal*                   CreateGoal05 (void);
-                    Goal*                   CreateGoal06 (void);
-                    Goal*                   CreateGoal07 (void);
-                    Goal*                   CreateGoal08 (void);
-                    Goal*                   CreateGoal09 (void);
 					ImodelIGC*              pShip;
 					ImissionIGC*			pMission;
-					ImodelIGC*				pStation;
+					//ImodelIGC*				pStation;
+                    Vector                  homeRedDoor;
 
     };
 }

--- a/src/training/mission8.h
+++ b/src/training/mission8.h
@@ -40,9 +40,9 @@ namespace Training
                     Goal*                   CreateGoal01 (void);
                     Goal*                   CreateGoal02 (void);
                     Goal*                   CreateGoal03 (void);
-					ImodelIGC*              pShip;
+					IshipIGC*               pShip;
 					ImissionIGC*			pMission;
-					//ImodelIGC*				pStation;
+					IstationIGC*			pStation;
                     Vector                  homeRedDoor;
 
     };

--- a/src/training/playsoundaction.cpp
+++ b/src/training/playsoundaction.cpp
@@ -38,7 +38,7 @@ namespace Training
         {
             /*ThingSitePrivate*           pThingSite = static_cast<ThingSitePrivate*> (trekClient.GetShip ()->GetThingSite());
             TRef<ISoundPositionSource>  pSource = pThingSite ? pThingSite->GetSoundSource () : NULL;*/
-            m_soundInstance = trekClient.StartSound (m_soundID, NULL); //use NULL instead of pSource, so the sounds doesn't stop on cluster change
+            m_soundInstance = trekClient.StartSound (m_soundID); //use NULL instead of pSource, so the sounds don't stop on cluster change
         }
         m_bHasStarted = true;
     }

--- a/src/training/playsoundaction.cpp
+++ b/src/training/playsoundaction.cpp
@@ -36,9 +36,9 @@ namespace Training
     {
         if (m_soundID != NA)
         {
-            ThingSitePrivate*           pThingSite = static_cast<ThingSitePrivate*> (trekClient.GetShip ()->GetThingSite());
-            TRef<ISoundPositionSource>  pSource = pThingSite ? pThingSite->GetSoundSource () : NULL;
-            m_soundInstance = trekClient.StartSound (m_soundID, pSource);
+            /*ThingSitePrivate*           pThingSite = static_cast<ThingSitePrivate*> (trekClient.GetShip ()->GetThingSite());
+            TRef<ISoundPositionSource>  pSource = pThingSite ? pThingSite->GetSoundSource () : NULL;*/
+            m_soundInstance = trekClient.StartSound (m_soundID, NULL); //use NULL instead of pSource, so the sounds doesn't stop on cluster change
         }
         m_bHasStarted = true;
     }

--- a/src/training/trainingmission.cpp
+++ b/src/training/trainingmission.cpp
@@ -300,8 +300,6 @@ namespace Training
           #endif
 
             // XXX hack to disable some keys in training
-            case TK_ViewCommand:
-            case TK_ConModeCommand:
             case TK_ConModeInvest:
             case TK_TargetSelf:
             case TK_Suicide:
@@ -311,8 +309,11 @@ namespace Training
             case TK_RejectCommand: // pkk - Some training missions can't be finished
                 if (GetMissionID() != 10) //Training::c_TM_10_Free_Flight
                     return false;
+            case TK_ViewCommand:
+            case TK_ConModeCommand:
+                if (!m_commandViewEnabled)
+                    return false;
                 //fallthrough otherwise
-
             default:
             {
                 // iterate over the key conditions with the unknown key

--- a/src/training/trainingmission.cpp
+++ b/src/training/trainingmission.cpp
@@ -502,8 +502,8 @@ namespace Training
     {
         ImissionIGC*        pCore = trekClient.ResetStaticData ();
         Time                now = pCore->GetLastUpdate();
-        char*               szStaticCoreFilename = IGC_STATIC_CORE_FILENAME;
-        int                 iStaticCoreVersion = LoadIGCStaticCore (szStaticCoreFilename, pCore, false);
+        char*               szTrainingCoreFilename = IGC_TRAINING_CORE_FILENAME;
+        int                 iStaticCoreVersion = LoadIGCStaticCore (szTrainingCoreFilename, pCore, false);
 
 
         // stuff for creating the sides
@@ -581,7 +581,7 @@ namespace Training
         // create the mission def
         FMD_S_MISSIONDEF    fmMissionDef;
         fmMissionDef.szDescription[0] = 0;
-        strcpy (fmMissionDef.misparms.szIGCStaticFile, szStaticCoreFilename);
+        strcpy (fmMissionDef.misparms.szIGCStaticFile, szTrainingCoreFilename);
         fmMissionDef.misparms.verIGCcore = iStaticCoreVersion;
         fmMissionDef.dwCookie = static_cast<DWORD> (pCore->GetMissionID ());
         fmMissionDef.iSideMissionOwner = 0;

--- a/src/training/trainingmission.cpp
+++ b/src/training/trainingmission.cpp
@@ -698,6 +698,8 @@ namespace Training
         fmPlayerInfo.dtidDrone = NA;
         fmPlayerInfo.shipID = shipID;
         fmPlayerInfo.cbrgPersistPlayerScores = 0;
+        if (m_commanderID != NA && pShip->GetObjectID() == m_commanderID)
+            fmPlayerInfo.fTeamLeader = true;
         pPlayerInfo->Set (&fmPlayerInfo);
         pPlayerInfo->SetMission (pMission);
 

--- a/src/training/trainingmission.cpp
+++ b/src/training/trainingmission.cpp
@@ -305,12 +305,12 @@ namespace Training
             case TK_Suicide:
             case TK_ConModeGameState:
             case TK_ConModeTeleport:
-            case TK_ToggleAutoPilot:
             case TK_RejectCommand: // pkk - Some training missions can't be finished
                 if (GetMissionID() != 10) //Training::c_TM_10_Free_Flight
                     return false;
             case TK_ViewCommand:
             case TK_ConModeCommand:
+            case TK_ToggleAutoPilot:
                 if (!m_commandViewEnabled)
                     return false;
                 //fallthrough otherwise
@@ -503,7 +503,7 @@ namespace Training
     {
         ImissionIGC*        pCore = trekClient.ResetStaticData ();
         Time                now = pCore->GetLastUpdate();
-        char*               szTrainingCoreFilename = IGC_TRAINING_CORE_FILENAME;
+        char*               szTrainingCoreFilename = IGC_TRAINING_CORE_FILENAME; //use IGC_STATIC_CORE_FILENAME for missions 1-5
         int                 iStaticCoreVersion = LoadIGCStaticCore (szTrainingCoreFilename, pCore, false);
 
 


### PR DESCRIPTION
**WARNING -- This relies on a map file in Artwork. Pull the thing over there too.**

**General**
- Use PCore012 for new looks and everything else
- Add teleport capability for training missions.
- Create treasures for jettison and blowing up ships.
- Ejecting vital modules not only leaves a treassure now, but also gets resupplied at a station
- Add the ability to skip goals.
- Make a station actually blow up instead of making it disappear.
- Training commander is flagged as commander for the visuals
- Add the missing aleph transition sound.
- Prevent giving enemies commands
 
**TM6 Combat Practice**
- Use Seeker 2 in tm6
- Make miners in tm6 destructible (and thus worth defending)
- Fix the enemy sector in tm6 (Their station is sideways and nothing else in there at all)
- Add a friendly teleport and enemy carrier

**TM7 Nanite**
- Rebalance tm7 pcore12, so only nanning the bomber will possibly fail. (The AI doesn't handle pcore13 movement so well..)
- spawn locations
- less time without controls
- F4 info, target items of interest
- skip already fulfilled goals
- too long -> repeat messages
- wait for player to be with bomber
- add end mission text and voice chat
- don't kill the player, just scare him (and avoid any issues)
- add the EXPLOSION
- re-send the bomber in case the player messes with it
- Saving loadout so it doesn't get overwritten at the station