### PR TITLE
Deactivate Join NOAT button when on NOAT

### DIFF
--- a/src/WinTrek/teamscreen.cpp
+++ b/src/WinTrek/teamscreen.cpp
@@ -1637,7 +1637,7 @@ public:
 		m_pbuttonDiscord->SetHidden(m_sideCurrent != trekClient.GetSideID());
 
         m_pbuttonJoin->SetEnabled(
-                (trekClient.GetSideID() == SIDE_TEAMLOBBY) // TE: Commented this from the brackets so you can always join NOAT: || !m_pMission->GetMissionParams().bLockSides
+                ((trekClient.GetSideID() == SIDE_TEAMLOBBY) && m_sideCurrent != SIDE_TEAMLOBBY) // TE: Commented this from the brackets so you can always join NOAT: || !m_pMission->GetMissionParams().bLockSides
                 || (m_sideCurrent == SIDE_TEAMLOBBY
                 || m_pMission->SideAvailablePositions(m_sideCurrent) > 0
                     && m_pMission->SideActive(m_sideCurrent))


### PR DESCRIPTION
https://trello.com/c/u4KPpwhh/236-teamscreen-the-join-team-button-is-active-when-on-noat-and-noat-is-currently-selected