### PR TITLE
Fix Spacebar or Tab not working in chat after launch/getting podkilled

### DIFF
--- a/src/WinTrek/WinTrek.cpp
+++ b/src/WinTrek/WinTrek.cpp
@@ -9566,11 +9566,13 @@ public:
 				case TK_ScrnShot:
 					TakeScreenShot();
 					return true;
-				// SR added ability to toggle virtual joystick during launch animation 8/06
+
+				// Toggle virtual joystick during launch animation
 				case TK_ToggleMouse:
 					if (trekClient.IsInGame() &&
 					GetViewMode() == vmOverride &&
-					!trekClient.IsLockedDown()) {
+					!trekClient.IsLockedDown() && 
+                    (m_pconsoleImage == NULL || !m_pconsoleImage->IsComposing())) {
 						m_bEnableVirtualJoystick = !m_bEnableVirtualJoystick;
 						if(m_bEnableVirtualJoystick) m_ptrekInput->ClearButtonStates();//#56
 						return true;


### PR DESCRIPTION
https://trello.com/c/T72ydqQD/255-spacebar-disabled-for-chat-during-launch-animation-or-after-getting-podkilled