### PR TITLE
Fix tower vs. drone message spam and lag.

### DIFF
--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -11954,12 +11954,15 @@ void FedSrvSiteBase::DamageShipEvent(Time now, IshipIGC* ship, ImodelIGC* launch
                                   underAttackSound, "Under attack by %s%s in %s",
                                   (PCC)strAllies, GetModelName(launcher), ship->GetCluster()->GetName());
 						
-						//7/22/09 ALLY FF
-						CFSShip*    pfsLauncher = (CFSShip*)(((IshipIGC*)(launcher))->GetPrivateData());
-						if (pfsLauncher->IsPlayer() && pside->AlliedSides(pside,psideLauncher))
+                        // Ally FF
+                        if (launcher->GetObjectType() == OT_ship)
                         {
-                            SendChat(ship, CHAT_INDIVIDUAL, launcher->GetObjectID(),
-                                     droneWatchFireSound, "Watch your fire");
+                            CFSShip* pfsLauncher = (CFSShip*)(((IshipIGC*)(launcher))->GetPrivateData());
+                            if (pfsLauncher->IsPlayer() && pside->AlliedSides(pside, psideLauncher))
+                            {
+                                SendChat(ship, CHAT_INDIVIDUAL, launcher->GetObjectID(),
+                                    droneWatchFireSound, "Watch your fire");
+                            }
                         }
                     }
                     else if (launcher != nullptr && launcher->GetObjectType() == OT_ship)


### PR DESCRIPTION
https://trello.com/c/tszr1Ci1/260-lans-the-tower-message-spam-is-just-huge-game-wide-lag-when-a-drone-travels-past-a-tower-you-get-continual-x-under-attack-messag