### PR TITLE
Fix restore loadout

### DIFF
--- a/src/clintlib/clintlib.h
+++ b/src/clintlib/clintlib.h
@@ -1555,9 +1555,9 @@ public:
                                         else
                                             lWrongMountMatch = l;
                                     }
-                                    if (!found && lWrongMountMatch)
-                                        lWrongMountMatch->data().bDuplicated = true;
                                 }
+                                if (!found && lWrongMountMatch)
+                                    lWrongMountMatch->data().bDuplicated = true;
                             }
                         }
                         else
@@ -1597,6 +1597,7 @@ public:
                         }
                         else if (cargo < 0)
                         {
+                            debugf(" Buy cargo part for %d\n", cargo);
                             BuyPartOnBudget(pshipSink, ppt, cargo++, &budget);
                         }
 

--- a/src/clintlib/clintlib.h
+++ b/src/clintlib/clintlib.h
@@ -1597,7 +1597,6 @@ public:
                         }
                         else if (cargo < 0)
                         {
-                            debugf(" Buy cargo part for %d\n", cargo);
                             BuyPartOnBudget(pshipSink, ppt, cargo++, &budget);
                         }
 

--- a/src/clintlib/clintlib.h
+++ b/src/clintlib/clintlib.h
@@ -1673,6 +1673,10 @@ public:
                         debugf("**** successor unable to mount %s/%s\n", pht->GetName(), ppt->GetName());
                 }
             }
+
+            //Fill any remaining slots with the default items if the hull type is upgraded
+            if (pcl->pht != pht)
+                TryToBuyParts(pship, pstation, &budget, pht, pht->GetPreferredPartTypes());
         }
         else
         {


### PR DESCRIPTION
Make the earlier fix work as intended.
Otherwise a gun switched to the cargo for example gets falsely marked as duplicated.

Also fix hvy ints launching with only two guns:
https://trello.com/c/YTymTyto/173-wasp-i-was-talking-to-masta-and-he-reminded-me-of-an-issue-that-i-believe-was-fixed-in-the-r8-release-when-your-hvy-int-upgrades