### PR TITLE
Utility AI

### DIFF
--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -3355,20 +3355,21 @@ bool CommandToDrone(CFSMission*         pfsMission,
                                             */
         }
 
-        if (pshipTo->GetPilotType() == c_ptMiner && 
-            (*ppmodelTarget) &&
-            (*ppmodelTarget)->GetObjectType() != OT_station && 
-            (*ppmodelTarget)->GetObjectType() != OT_ship)
-        {
-            pshipTo->SetCommand(c_cmdQueued, (ImodelIGC*)(*ppmodelTarget)->GetCluster(), c_cidDefault);
-        }
-        else
-            pshipTo->SetCommand(c_cmdQueued, NULL, c_cidNone);
+        if (pshipTo->GetPilotType() == c_ptMiner) {
+            if ((*ppmodelTarget) &&
+                (*ppmodelTarget)->GetObjectType() != OT_station &&
+                (*ppmodelTarget)->GetObjectType() != OT_ship)
+            {
+                pshipTo->SetCommand(c_cmdQueued, (ImodelIGC*)(*ppmodelTarget)->GetCluster(), c_cidDefault);
+            }
+            else
+                pshipTo->SetCommand(c_cmdQueued, NULL, c_cidNone);
 
-        if (pminerCluster) {
-            if ((*ppmodelTarget)->GetObjectType() == OT_buoy) 
-                (*ppmodelTarget)->Release();
-            *ppmodelTarget = NULL; //no more clean-up needed
+            if (pminerCluster) {
+                if ((*ppmodelTarget)->GetObjectType() == OT_buoy)
+                    (*ppmodelTarget)->Release();
+                *ppmodelTarget = NULL; //no more clean-up needed
+            }
         }
     }
 

--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -3185,16 +3185,22 @@ bool CommandToDrone(CFSMission*         pfsMission,
     if ((pcd->commandID != c_cidNone) &&
         (pfsSender->GetIGCShip()->GetSide() == pside))
     {
-
+        IclusterIGC* pminerCluster = NULL;
+        char pcReply[100] = "Affirmative.";
         if (*ppmodelTarget == NULL)
 		{
             if (pdb)
             {
-                //Create a buoy for this chat message
-                *ppmodelTarget = (ImodelIGC*)(pfsMission->GetIGCMission()->CreateObject(g.timeNow, OT_buoy, pdb, sizeof(*pdb)));
-                assert (*ppmodelTarget);
+                if (pshipTo->GetPilotType() == c_ptMiner && pdb->type == c_buoyCluster) {
+                    pminerCluster = pfsMission->GetIGCMission()->GetCluster(pdb->clusterID);
+                }
+                else {
+                    //Create a buoy for this chat message
+                    *ppmodelTarget = (ImodelIGC*)(pfsMission->GetIGCMission()->CreateObject(g.timeNow, OT_buoy, pdb, sizeof(*pdb)));
+                    assert (*ppmodelTarget);
 
-                ((IbuoyIGC*)*ppmodelTarget)->AddConsumer();
+                    ((IbuoyIGC*)*ppmodelTarget)->AddConsumer();
+                }
             }
             else
             {
@@ -3225,6 +3231,81 @@ bool CommandToDrone(CFSMission*         pfsMission,
 					}
 				}
 				//
+                else if (pshipTo->GetPilotType() == c_ptMiner && otTarget == OT_warp) {
+                    IwarpIGC* pwarp = (IwarpIGC*)(*ppmodelTarget);
+                    IwarpIGC* pothersideWarp = pwarp ? pwarp->GetDestination() : NULL;
+                    if (pothersideWarp)
+                        pminerCluster = pothersideWarp->GetCluster();
+                }
+            }
+
+            if (pminerCluster) {
+                IstationIGC* pstationToDock = NULL;
+                for (StationLinkIGC* l = pminerCluster->GetStations()->first(); (l != NULL); l = l->next()) {
+                    IstationIGC* pcurStation = l->data();
+                    if (pcurStation->GetSide() == pside) {
+                        pstationToDock = pcurStation;
+                        break;
+                    }
+                }
+                bool mine = false;
+
+                CompactShipFractions fractions;
+                pshipTo->ExportFractions(&fractions);
+                float capacity = pside->GetMission()->GetFloatConstant(c_fcidCapacityHe3) *
+                    pside->GetGlobalAttributeSet().GetAttribute(c_gaMiningCapacity);
+                // Should we try to mine?
+                if ((fractions.GetShieldFraction()>0.5 || !pstationToDock) &&
+                    (pshipTo->GetOre() < capacity / 2.0f || (!pstationToDock && pshipTo->GetOre() < capacity))) 
+                {
+                    ImodelIGC*  pmodel = FindTarget(pshipTo,
+                        c_ttNeutral | c_ttAsteroid | c_ttNearest |
+                        c_ttLeastTargeted | c_ttCowardly,
+                        NULL, pminerCluster, &(pshipTo->GetPosition()), NULL,
+                        pshipTo->GetOrdersABM());
+
+                    if (pmodel) {
+                        sprintf(pcReply, "Affirmative, going to mine in %s.", pminerCluster->GetName());
+                        *ppmodelTarget = pmodel;
+                        pcd->commandID = c_cidMine;
+                        mine = true;
+                    }
+                }
+
+                if (!mine) {
+                    if (pstationToDock) {
+                        sprintf(pcReply, "Affirmative, going to dock in %s.", pminerCluster->GetName());
+                        *ppmodelTarget = pstationToDock;
+                        pcd->commandID = c_cidGoto;
+                    }
+                    else {
+                        // check if the side has explored the sector
+                        bool knownSector = false;
+                        for (AsteroidLinkIGC* l = pminerCluster->GetAsteroids()->first(); (l != NULL); l = l->next()) {
+                            IasteroidIGC* pcurRoid = l->data();
+                            if (pcurRoid->SeenBySide(pside)) {
+                                knownSector = true;
+                                break;
+                            }
+                        }
+
+                        DataBuoyIGC         buoyData;
+                        buoyData.position = Vector(0.0f, 0.0f, 0.0f);
+                        if (!knownSector && pshipTo->GetOre() < capacity / 2.0f) {
+                            //debugf(" send the miner just inside the sector, will find an asteroid there.\n");
+                            buoyData.type = c_buoyCluster;
+                        }
+                        else {
+                            //debugf(" send the miner to the center of the sector.\n");
+                            buoyData.type = c_buoyWaypoint;
+                        }
+                        buoyData.clusterID = pminerCluster->GetObjectID();
+                        buoyData.buoyID = pfsMission->GetIGCMission()->GenerateNewBuoyID();
+
+                        *ppmodelTarget = (ImodelIGC*)(pfsMission->GetIGCMission()->CreateObject(g.timeNow, OT_buoy, &buoyData, sizeof(buoyData)));
+                        pcd->commandID = c_cidGoto;
+                    }
+                }
             }
         }
         if ((pcd->commandID == c_cidDefault) && (*ppmodelTarget != NULL))
@@ -3237,7 +3318,7 @@ bool CommandToDrone(CFSMission*         pfsMission,
             pshipTo->SetStayDocked(false);  //Xynth #48 8/2010 reset staydocked on any command
 			bAccepted = true;
             pfsMission->GetSite()->SendChat(pshipTo, CHAT_INDIVIDUAL, pfsSender->GetIGCShip()->GetObjectID(),
-                                            voAffirmativeSound, "Affirmative.");
+                                            voAffirmativeSound, pcReply);
 
             if (pcd->commandID == c_cidJoin)
             {
@@ -3257,11 +3338,11 @@ bool CommandToDrone(CFSMission*         pfsMission,
             }
             else
             {
-                //Set both current and accepted commands
+                /*//Set both current and accepted commands
                 pshipTo->SetCommand(c_cmdCurrent,
                                     *ppmodelTarget,
-                                    pcd->commandID);
-                pshipTo->SetCommand(c_cmdAccepted,
+                                    pcd->commandID);*/
+                pshipTo->SetCommand(c_cmdAccepted, //sets c_cmdCurrent as well
                                     *ppmodelTarget,
                                     pcd->commandID);
             }
@@ -3272,6 +3353,22 @@ bool CommandToDrone(CFSMission*         pfsMission,
             pfsMission->GetSite()->SendChat(pshipTo, CHAT_INDIVIDUAL, pfsSender->GetIGCShip()->GetObjectID(),
                                             voNegativeSound, "Negative.");
                                             */
+        }
+
+        if (pshipTo->GetPilotType() == c_ptMiner && 
+            (*ppmodelTarget) &&
+            (*ppmodelTarget)->GetObjectType() != OT_station && 
+            (*ppmodelTarget)->GetObjectType() != OT_ship)
+        {
+            pshipTo->SetCommand(c_cmdQueued, (ImodelIGC*)(*ppmodelTarget)->GetCluster(), c_cidDefault);
+        }
+        else
+            pshipTo->SetCommand(c_cmdQueued, NULL, c_cidNone);
+
+        if (pminerCluster) {
+            if ((*ppmodelTarget)->GetObjectType() == OT_buoy) 
+                (*ppmodelTarget)->Release();
+            *ppmodelTarget = NULL; //no more clean-up needed
         }
     }
 
@@ -8215,12 +8312,12 @@ IHTTPSession * BeginConfigDownload()
   CRegKey key;
   if (ERROR_SUCCESS == key.Open(HKEY_LOCAL_MACHINE, HKLM_FedSrv, KEY_READ))
   {
-    ZString strConfig;
-    if (SUCCEEDED(LoadRegString(key, "cfgfile", strConfig)))
-    {
-      // if reg value exists copy over default
-      strcpy(szConfig, PCC(strConfig));
-    }
+      ZString strConfig;
+      if (SUCCEEDED(LoadRegString(key, "cfgfile", strConfig)))
+      {
+          // if reg value exists copy over default
+          strcpy(szConfig, PCC(strConfig));
+      }
   }
 
   // WLP 2006 - added next line of code to force server to report invalid config
@@ -8502,7 +8599,7 @@ bool RetrieveCFGFile() // returns true if cfg was successfully retrieved
 
   if (pHTTPSession)
   {
-    debugf("Downloading cfg file...");
+      debugf("Downloading cfg file...");
 
     // we block as we download the cfg file; should be okay since we are not connected to the zone.
     while(pHTTPSession->ContinueDownload())
@@ -8630,8 +8727,8 @@ HRESULT ConnectToLobby(const char * pszLobby_OverrideCFG /* NULL == do not overr
   // find out what lobby to use and/or autoupdate info
   if (!pszLobby_OverrideCFG){
 #if defined(ALLSRV_STANDALONE)
-	  if (!RetrieveCFGFile())
-		return HRESULT_FROM_WIN32(ERROR_CRC);
+      if (!RetrieveCFGFile())
+          return HRESULT_FROM_WIN32(ERROR_CRC);
 #endif
   } else {
 	  g.strLobbyServer = pszLobby_OverrideCFG;
@@ -10866,6 +10963,8 @@ class ThingSiteImpl : public ThingSite
                                             ObjectType  otSpotter = s->GetObjectType();
 											//Imago #121
 											if (otModel == OT_station) {
+                                                pside->UpdateTerritory();
+
 												ObjectID roidID = static_cast<IstationIGC*>(pmodel)->GetRoidID();
 												//asteroid to silently pop
 												if (roidID != NA) {
@@ -10986,6 +11085,10 @@ class ThingSiteImpl : public ThingSite
                         HideObject(pside, m_pmodel);
                 }
 				sv.CurrentEyed(fVisible);  //Xynth #100 7/2010
+
+                if (fVisible && m_pmodel->GetObjectType() == OT_station) { //Not usually going to happen
+                    pside->UpdateTerritory(); 
+                }
             }
         }
 
@@ -11176,12 +11279,19 @@ void FedSrvSiteBase::StationTypeCompleted(IbucketIGC * pbucket, IstationIGC* pst
         pfsDrone->GetIGCShip()->PickDefaultOrder(pstation->GetCluster(), pstation->GetPosition(), true);
         pfsDrone->GetIGCShip()->SetStation(NULL);       //but quickly undock them
 
-        // request a rock.
-        if (pfsDrone->GetIGCShip()->GetCommandID(c_cmdCurrent) != c_cidBuild)
-        {
-            SendChat(pfsDrone->GetIGCShip(), CHAT_TEAM, pfsDrone->GetIGCShip()->GetSide()->GetObjectID(),
-                pstationtype->GetConstructorNeedRockSound(), "New constructor requesting asteroid.");
+        //Don't auto-build
+        if (pfsDrone->GetIGCShip()->GetCommandID(c_cmdCurrent) == c_cidBuild) {
+            ImodelIGC* targetRock = pfsDrone->GetIGCShip()->GetCommandTarget(c_cmdCurrent);
+            // Queue doing nothing
+            pfsDrone->GetIGCShip()->SetCommand(c_cmdAccepted, NULL, c_cidDoNothing);
+            // move to the possible rock
+            pfsDrone->GetIGCShip()->SetCommand(c_cmdPlan, targetRock, c_cidGoto);
+            pfsDrone->GetIGCShip()->SetCommand(c_cmdCurrent, targetRock, c_cidGoto);
         }
+
+        // request a rock.
+        SendChat(pfsDrone->GetIGCShip(), CHAT_TEAM, pfsDrone->GetIGCShip()->GetSide()->GetObjectID(),
+            pstationtype->GetConstructorNeedRockSound(), "New constructor requesting asteroid.");
     }
 }
 
@@ -11359,7 +11469,7 @@ void FedSrvSiteBase::DroneTypeCompleted(IbucketIGC * pbucket, IstationIGC* pstat
         else if ((pdronetype->GetPilotType() == c_ptMiner) && (pfsDrone->GetIGCShip()->GetCommandID(c_cmdCurrent) != c_cidMine))
         {
             SendChat(pfsDrone->GetIGCShip(), CHAT_TEAM, pfsDrone->GetIGCShip()->GetSide()->GetObjectID(),
-                droneWhereToSound, "New miner requesting He3 asteriod.");
+                droneWhereToSound, "New miner requesting He3 asteroid.");
         }
       }
   }
@@ -12203,6 +12313,10 @@ void FedSrvSiteBase::KillStationEvent(IstationIGC* pstation, ImodelIGC* plaunche
 
 
   pstation->Terminate();
+
+  for (SideLinkIGC* l = pside->GetMission()->GetSides()->first(); (l != NULL); l = l->next()) {
+      l->data()->UpdateTerritory();
+  }
 
   /*
   //NYI: hack to test simultaneous death

--- a/src/FedSrv/fsship.cpp
+++ b/src/FedSrv/fsship.cpp
@@ -681,6 +681,13 @@ void CFSShip::CaptureStation(IstationIGC * pstation)
   }
   else if (psideOld->GetActiveF())						//RESET OUR EYE HERE?  IMAGO CAPTURE EYE BUG FIX?  REVIEW 7/23/09
       m_pfsMission->VacateStation(pstation);
+
+  for (SideLinkIGC* l = pside->GetMission()->GetSides()->first(); (l != NULL); l = l->next()) {
+      IsideIGC* pcurSide = l->data();
+      if (pcurSide == pside || pcurSide == psideOld || IsideIGC::AlliedSides(pside, pcurSide) || IsideIGC::AlliedSides(psideOld, pcurSide)) {
+          l->data()->UpdateTerritory();
+      }
+  }
 }
 
 void CFSShip::QueueLoadoutChange(bool bForce)

--- a/src/Igc/common.cpp
+++ b/src/Igc/common.cpp
@@ -660,7 +660,7 @@ ImodelIGC*  FindTarget(IshipIGC*           pship,
                             if (clustersVisited.find(pclusterOther) == NULL)
                             {
                                 //No
-                                if (((ttMask & c_ttCowardly) == 0) || IsFriendlyCluster(pclusterOther, pside))
+                                if (((ttMask & c_ttCowardly) == 0) || pside->IsTerritory(pclusterOther))
                                     pwlTwoAway->last(pwarpDestination);
                             }
                         }

--- a/src/Igc/igc.h
+++ b/src/Igc/igc.h
@@ -4267,6 +4267,11 @@ class IsideIGC : public IbaseIGC
 
 		//Xynth Adding function to return number of players on a side
 		virtual int GetNumPlayersOnSide(void) const = 0;
+
+        //Territory clusters
+        virtual void UpdateTerritory() = 0;
+        virtual ClusterListIGC GetTerritory() = 0;
+        virtual bool IsTerritory(IclusterIGC* pcluster) = 0;
 };
 
 class IcivilizationIGC : public IbaseIGC

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -2108,7 +2108,7 @@ void    CshipIGC::PlotShipMove(Time          timeStop)
                                 NULL, NULL, NULL, NULL, c_sabmUnload);
 
                         if (pmodel) {
-                            if (pasteroid->GetOreFraction() < 0.2) {            //Don't reserve the rock and go back, if it's almost mined out
+                            if (pasteroid->GetOre() < capacity * 0.5f) {        //Don't reserve the rock and go back, if it's almost mined out
                                 SetCommand(c_cmdAccepted, pmodel, c_cidGoto);   // Also sets c_cmdCurrent and c_cmdPlan
                             }
                             else

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -2108,7 +2108,7 @@ void    CshipIGC::PlotShipMove(Time          timeStop)
                                 NULL, NULL, NULL, NULL, c_sabmUnload);
 
                         if (pmodel) {
-                            if (pasteroid->GetOreFraction() <= 0.1) {           //Don't reserve the rock and go back, if it's almost mined out
+                            if (pasteroid->GetOreFraction() < 0.2) {            //Don't reserve the rock and go back, if it's almost mined out
                                 SetCommand(c_cmdAccepted, pmodel, c_cidGoto);   // Also sets c_cmdCurrent and c_cmdPlan
                             }
                             else

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -1915,7 +1915,7 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
                         IstationIGC*    pstation = (IstationIGC*)((ImodelIGC*)m_commandTargets[c_cmdPlan]);
                         if (pstation->GetBaseStationType()->HasCapability(c_sabmTeleportUnload))
                         {
-                            //Are we close enough to mine our target asteroid? // mmf incorrect comment
+                            //Are we close enough to teleport offload (at refinery)?
                             Vector  dp = pstation->GetPosition() - positionMe;
                             float   distance2 = dp.LengthSquared();
                             float   radius = pstation->GetRadius() + GetRadius() + 100.0f;
@@ -2101,12 +2101,21 @@ void    CshipIGC::PlotShipMove(Time          timeStop)
                 {
                     minedOre = capacity - m_fOre;
                     {
-                        ImodelIGC*  pmodel = FindTarget(this, c_ttFriendly | c_ttStation | c_ttNearest | c_ttAnyCluster,
+                        ImodelIGC*  pmodel = FindTarget(this, c_ttFriendly | c_ttStation | c_ttNearest | c_ttAnyCluster | c_ttCowardly,
                                                         NULL, NULL, NULL, NULL, c_sabmUnload);
+                        if (!pmodel) //no safe station available
+                            pmodel = FindTarget(this, c_ttFriendly | c_ttStation | c_ttNearest | c_ttAnyCluster,
+                                NULL, NULL, NULL, NULL, c_sabmUnload);
 
+                        if (pmodel) {
+                            if (pasteroid->GetOreFraction() <= 0.1) {           //Don't reserve the rock and go back, if it's almost mined out
+                                SetCommand(c_cmdAccepted, pmodel, c_cidGoto);   // Also sets c_cmdCurrent and c_cmdPlan
+                            }
+                            else
+                                SetCommand(c_cmdPlan, pmodel, c_cidGoto);       // c_cmdAccepted unchanged - will come back
+                        }
                         //If we can't find a place to unload ... stick around here for lack of a better place to go
-                        if (pmodel)
-                            SetCommand(c_cmdPlan, pmodel, c_cidGoto);
+
 						// mmf added else and debugf
 						// else debugf("mmf %-20s no place to unload staying here, I am at %f %f %f\n",
 						// 						GetName(), GetPosition().x, GetPosition().y, GetPosition().z);
@@ -2183,12 +2192,12 @@ void    CshipIGC::PlotShipMove(Time          timeStop)
 
         if (m_commandTargets[c_cmdPlan] == NULL)
         {
-            if ((m_pilotType < c_ptCarrier) && (m_commandIDs[c_cmdPlan] != c_cidDoNothing))
+            if (m_pilotType < c_ptCarrier) //&& (m_commandIDs[c_cmdPlan] != c_cidDoNothing))
             {
                 switch (m_pilotType)
                 {
                     case c_ptMiner:
-                        Complain(droneWhereToSound, "Miner requesting He3 asteriod.");
+                        Complain(droneWhereToSound, "Miner requesting He3 asteroid.");
                         break;
 
                     case c_ptBuilder:

--- a/src/Igc/shipIGC.h
+++ b/src/Igc/shipIGC.h
@@ -2155,7 +2155,7 @@ class       CshipIGC : public TmodelIGC<IshipIGC>
                         ImodelIGC*  pmodel = NULL;
 
                         // Check if there is a player command we should be continuing
-                        if (m_commandTargets[c_cmdQueued] && m_commandIDs[c_cmdQueued] == c_cidDefault && bDocked) {
+                        if (m_commandTargets[c_cmdQueued] && m_commandIDs[c_cmdQueued] == c_cidDefault) {
                             IclusterIGC* pcommandCluster = (IclusterIGC*)(m_commandTargets[c_cmdQueued]);
                             assert(pcommandCluster);
                             pmodel = FindTarget(this,

--- a/src/Igc/sideigc.h
+++ b/src/Igc/sideigc.h
@@ -591,8 +591,22 @@ class       CsideIGC : public IsideIGC
 		{
 			return m_data.allies;
 		}
+
+        void UpdateTerritory();
+
+        ClusterListIGC GetTerritory() 
+        {
+            return m_territoryClusters;
+        }
+
+        bool IsTerritory(IclusterIGC* pcluster)
+        {
+            return (m_territoryClusters.find(pcluster) != NULL);
+        }
 		
     private:
+        bool IsSurroundedByTerritory(IclusterIGC* pcluster, ClusterListIGC* clustersLinked, ClusterListIGC* clustersTerritory, int currentDepth = 0);
+
         void    AdjustBuckets(void)
         {
             //Empty the side buckets we can no longer build
@@ -671,6 +685,7 @@ class       CsideIGC : public IsideIGC
         StationListIGC      m_stations;
         BucketListIGC       m_buckets;
         ShipListIGC         m_ships;
+        ClusterListIGC      m_territoryClusters;
 
         StockpileList       m_stockpile;
 

--- a/src/Igc/stationIGC.cpp
+++ b/src/Igc/stationIGC.cpp
@@ -76,6 +76,8 @@ HRESULT     CstationIGC::Initialize(ImissionIGC* pMission, Time now, const void*
 
             m_hullFraction = dataStation->bpHull;
             SetShieldFraction(dataStation->bpShield);
+
+            this->GetSide()->UpdateTerritory();
         }
 
         m_timeLastDamageReport = now;

--- a/src/clintlib/appmsg.cpp
+++ b/src/clintlib/appmsg.cpp
@@ -1840,7 +1840,7 @@ HRESULT BaseClient::HandleMsg(FEDMESSAGE* pfm,
                         if (pfmOC->commandID == c_cidMine) {
                             PlayerInfo* ppi = (PlayerInfo*)(pship->GetPrivateData());
                             if (ppi && pmodel && ppi->LastSeenSector() != pmodel->GetCluster()->GetObjectID())
-                                PostText(false, "%s: Going to mine in %s.", pship->GetName(), pmodel->GetCluster()->GetName());
+                                PostText(false, "%s: Going to mine %s in %s.", pship->GetName(), pmodel->GetName(), pmodel->GetCluster()->GetName());
                         }
                     }
                     else if (pfmOC->command == c_cmdCurrent)

--- a/src/clintlib/appmsg.cpp
+++ b/src/clintlib/appmsg.cpp
@@ -1161,8 +1161,8 @@ HRESULT BaseClient::HandleMsg(FEDMESSAGE* pfm,
                         {
                             // The ship has moved to the same cluster as the player
                             debugf("Moving %s/%d to %s\n",
-                                   ship->GetName(), ship->GetObjectID(),
-                                   pcluster->GetName());
+                                ship->GetName(), ship->GetObjectID(),
+                                pcluster->GetName());
 
                             ship->SetCluster(pcluster);
                             ship->SetLastUpdate(time);
@@ -1833,8 +1833,16 @@ HRESULT BaseClient::HandleMsg(FEDMESSAGE* pfm,
                 {
                     ImodelIGC*  pmodel = m_pCoreIGC->GetModel(pfmOC->objectType, pfmOC->objectID);
 
-                    if (pship != m_ship)
+                    if (pship != m_ship) {
                         pship->SetCommand(pfmOC->command, pmodel, pfmOC->commandID);
+
+                        // Post notification for miners
+                        if (pfmOC->commandID == c_cidMine) {
+                            PlayerInfo* ppi = (PlayerInfo*)(pship->GetPrivateData());
+                            if (ppi && pmodel && ppi->LastSeenSector() != pmodel->GetCluster()->GetObjectID())
+                                PostText(false, "%s: Going to mine in %s.", pship->GetName(), pmodel->GetCluster()->GetName());
+                        }
+                    }
                     else if (pfmOC->command == c_cmdCurrent)
                         m_pmodelServerTarget = pmodel;
 


### PR DESCRIPTION
- Don't have a tech con auto-build at home
- Make miners not mine contested sectors (as in sectors with bases from both sides)
- Allow miners to mine empty sectors surrounded by friendly sectors
- Be smarter about undocking if there are enemy ships around the station.
- Don't return to finish mining an almost empty rock if there are better
- Post notification when going to mine in another sector
- If being sent to a sector, chose a good action, so the miner doesn't fly right back into trouble.
- Remember player commands after unloading.

Mostly server side changes. Tested them in local 1vs1 games.

https://trello.com/c/3y7malsj/267-comm-qol-improve-utility-ai