### PR TITLE
Sort target priorities for tower probes

### DIFF
--- a/src/Igc/probeigc.cpp
+++ b/src/Igc/probeigc.cpp
@@ -399,25 +399,24 @@ void    CprobeIGC::Update(Time now)
                 }
                 else
                 {
-                    if (eabm & c_eabmShootShips)
+                    if (eabm & c_eabmShootStations)
                     {
-                        //Threats to stations get highest priority
+                        GetTarget((const ModelListIGC*)(pcluster->GetStations()),
+                            pside, myPosition, dtUpdate, accuracy, speed, lifespan, OT_station,
+                            &pmodelTarget, &distance2Min, &directionMin);
+                    }
+
+                    if (!pmodelTarget && (eabm & c_eabmShootShips))
+                    {
                         GetTarget((const ModelListIGC*)(pcluster->GetShips()),
                                   pside, myPosition, dtUpdate, accuracy, speed, lifespan, OT_ship,
                                   &pmodelTarget, &distance2Min, &directionMin);
                     }
 
-                    if (eabm & c_eabmShootMissiles)
+                    if (!pmodelTarget && (eabm & c_eabmShootMissiles))
                     {
                         GetTarget((const ModelListIGC*)(pcluster->GetMissiles()),
                                   pside, myPosition, dtUpdate, accuracy, speed, lifespan, OT_missile, 
-                                  &pmodelTarget, &distance2Min, &directionMin);
-                    }
-
-                    if (eabm & c_eabmShootStations)
-                    {
-                        GetTarget((const ModelListIGC*)(pcluster->GetStations()),
-                                  pside, myPosition, dtUpdate, accuracy, speed, lifespan, OT_station, 
                                   &pmodelTarget, &distance2Min, &directionMin);
                     }
                 }


### PR DESCRIPTION
https://trello.com/c/jJgxK5K5/272-towers-think-its-a-good-idea-to-shoot-at-dumbfire-missiles-instead-of-the-ship-launching-them

This changes what the server calculates AND what the client sees. So looks weird if only one is updated..