### PR TITLE
Modify BuyDefaultLoadout() to ignore pulse probes.

### DIFF
--- a/src/clintlib/clintlib.h
+++ b/src/clintlib/clintlib.h
@@ -2020,8 +2020,11 @@ public:
             assert(pptDispenser);
             assert(pptDispenser->GetGroupID() >= 0);
 
-            if (!pstation->CanBuy(pptDispenser))
+            if (!pstation->CanBuy(pptDispenser) ||
+                pptDispenser->GetPartMask() == 0x2) //ignore int pulse probes
+            {
                 pptDispenser = NULL;
+            }
         }
         else
             pptDispenser = NULL;

--- a/src/clintlib/clintlib.h
+++ b/src/clintlib/clintlib.h
@@ -2021,7 +2021,7 @@ public:
             assert(pptDispenser->GetGroupID() >= 0);
 
             if (!pstation->CanBuy(pptDispenser) ||
-                pptDispenser->GetPartMask() == 0x2) //ignore int pulse probes
+                pptDispenser->GetPartMask() == c_pbm2) //ignore int pulse probes
             {
                 pptDispenser = NULL;
             }


### PR DESCRIPTION
https://trello.com/c/yCV4hhxW/273-change-int-cargo-default-to-ignore-pulse-probes