### PR TITLE
Add sidethrust sound support

### DIFF
--- a/src/Igc/sounds.h
+++ b/src/Igc/sounds.h
@@ -506,6 +506,11 @@ DEFSOUND(salChangeSides)
 DEFSOUND(salEnemyJoiners)
 DEFSOUND(salEnemyLeaves)
 
+
+//Sidethrusters
+DEFSOUND(SidethrustInterior)
+DEFSOUND(SidethrustExterior)
+
 // pigs
 DEFSOUND(oink1) // Pig response
 DEFSOUND(oink2) // Pig response

--- a/src/WinTrek/trekigc.cpp
+++ b/src/WinTrek/trekigc.cpp
@@ -740,12 +740,14 @@ private:
     TRef<ISoundInstance> m_pMainThrusterInteriorSound;
     TRef<ISoundInstance> m_pTurnThrusterInteriorSound;
     TRef<ISoundInstance> m_pAfterburnerInteriorSound;
+	TRef<ISoundInstance> m_pSideThrustInteriorSound;
 
     // sounds used outside of a ship
     TRef<ISoundInstance> m_pExteriorSound;
     TRef<ISoundInstance> m_pMainThrusterExteriorSound;
     TRef<ISoundInstance> m_pTurnThrusterExteriorSound;
     TRef<ISoundInstance> m_pAfterburnerExteriorSound;
+	TRef<ISoundInstance> m_pSideThrustExteriorSound;
     TRef<ISoundInstance> m_pMiningSound;
 
     // weapon sounds for each mount
@@ -1299,6 +1301,8 @@ public:
                 PlaySoundIf(m_pAfterburnerInteriorSound, 
                     GetAfterburnerSoundID(true), 
                     m_psourceEngine, AfterburnerPower() > 0.0f);
+				//Sidethrusters
+				PlaySoundIf(m_pSideThrustInteriorSound, SidethrustInteriorSound, GetSoundSource(), SidewaysThrustFraction() > 0.01f);
             }
 
             //
@@ -1316,6 +1320,8 @@ public:
                 GetAfterburnerSoundID(false), 
                 m_psourceEngine,
                 AfterburnerPower() > 0.0f);
+			//Sidethrusters
+			PlaySoundIf(m_pSideThrustExteriorSound, SidethrustExteriorSound, GetSoundSource(), SidewaysThrustFraction() > 0.01f);
 
             UpdateEngineSoundLevels(dwElapsedTime);
 


### PR DESCRIPTION
Must include these lines in sounddef.mdl in Artwork:

//
//Sidethrusters
//
SidethrustInteriorSound        = GainSound(SFXGain, ThreeDSound(100, LoopingSound(ImportWave("accelSmall"))));
SidethrustExteriorSound        = GainSound(SFXGain, ThreeDSound(100, LoopingSound(ImportWave("accelSmall"))));


Then lower down in the soundlist table, must add:

		//Sidethrusters
		(SidethrustInteriorSoundId, SidethrustInteriorSound),
		(SidethrustExteriorSoundId, SidethrustExteriorSound),