### PR TITLE
Modding support

### DIFF
--- a/VS2017/Utility.vcxproj
+++ b/VS2017/Utility.vcxproj
@@ -60,7 +60,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='FZDebug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\src\lib\Steam;..\src\Inc;..\src\_Utility;..\src\WinTrek;..\src\ZLib;..\src\Guids;..\src\Zone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\Lib\AllegianceSecurity;..\src\lib\Steam;..\src\Inc;..\src\_Utility;..\src\WinTrek;..\src\ZLib;..\src\Guids;..\src\Zone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_AFXDLL;WIN32;_WINDOWS;STRICT;_DEBUG;DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -78,7 +78,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='FZRetail|Win32'">
     <ClCompile>
       <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>..\src\lib\Steam;..\src\Inc;..\src\_Utility;..\src\WinTrek;..\src\ZLib;..\src\Guids;..\src\Zone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\Lib\AllegianceSecurity;..\src\lib\Steam;..\src\Inc;..\src\_Utility;..\src\WinTrek;..\src\ZLib;..\src\Guids;..\src\Zone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;DEBUG;SRVLOG;_AFXDLL;WIN32;_WINDOWS;STRICT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>true</BufferSecurityCheck>
@@ -106,6 +106,7 @@
     <ClCompile Include="..\src\_Utility\CollisionQueue.cpp" />
     <ClCompile Include="..\src\_Utility\CRC.cpp" />
     <ClCompile Include="..\src\_Utility\Endpoint.cpp" />
+    <ClCompile Include="..\src\_Utility\FileLoader.cpp" />
     <ClCompile Include="..\src\_Utility\HitTest.cpp" />
     <ClCompile Include="..\src\_Utility\KDnode.cpp" />
     <ClCompile Include="..\src\_Utility\KDroot.cpp" />
@@ -119,6 +120,7 @@
   <ItemGroup>
     <ClInclude Include="..\src\Inc\MessageVersion.h" />
     <ClInclude Include="..\src\_Utility\CRC.h" />
+    <ClInclude Include="..\src\_Utility\FileLoader.h" />
     <ClInclude Include="..\src\_Utility\listwrappers.h" />
     <ClInclude Include="..\src\_Utility\pch.h" />
     <ClInclude Include="..\src\_Utility\Utility.h" />

--- a/VS2017/effect.vcxproj
+++ b/VS2017/effect.vcxproj
@@ -61,7 +61,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='FZDebug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\src\SoundEngine;..\src\Inc;..\src\ZLib;..\src\Engine;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\SoundEngine;..\src\Inc;..\src\ZLib;..\src\_Utility;..\src\Engine;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;D3D_DEBUG_INFO;WIN32;_WINDOWS;STRICT;DEBUG;_DEBUG;_AFXDLL;DIRECTINPUT_VERSION=0x0800;__MODULE__#"Effect";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -83,7 +83,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>..\src\SoundEngine;..\src\Inc;..\src\ZLib;..\src\Engine;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\SoundEngine;..\src\Inc;..\src\ZLib;..\src\_Utility;..\src\Engine;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;SRVLOG;_LIB;WIN32;_WINDOWS;STRICT;DEBUG;_AFXDLL;DIRECTINPUT_VERSION=0x0800;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>

--- a/VS2017/mdlc.vcxproj
+++ b/VS2017/mdlc.vcxproj
@@ -69,7 +69,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='FZDebug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\src\Inc;..\src\lib\Steam;../src/Zlib;../src/Engine;../src/Effect;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../src/_Utility;..\src\Inc;..\src\lib\Steam;../src/Zlib;../src/Engine;../src/Effect;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_AFXDLL;WIN32;_WINDOWS;STRICT;_DEBUG;DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -104,7 +104,7 @@ xcopy $(ProjectDir)..\src\Inc\steam_appid.txt $(OutDir) /s /d /y</Command>
     <ClCompile>
       <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>..\src\Inc;..\src\lib\Steam;../src/Zlib;../src/Engine;../src/Effect;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../src/_Utility;..\src\Inc;..\src\lib\Steam;../src/Zlib;../src/Engine;../src/Effect;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DEBUG;SRVLOG;WIN32;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>true</BufferSecurityCheck>

--- a/VS2017/mdledit.vcxproj
+++ b/VS2017/mdledit.vcxproj
@@ -69,7 +69,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='FZDebug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\src\Inc;..\src\lib\Steam;../src/effect;../src/Engine;../src/ZLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\Inc;..\src\lib\Steam;../src/effect;../src/_Utility;../src/Engine;../src/ZLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <ExceptionHandling>
@@ -111,7 +111,7 @@ xcopy $(ProjectDir)..\src\Inc\steam_appid.txt $(OutDir) /s /d /y</Command>
       <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
       <OmitFramePointers>false</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\src\Inc;..\src\lib\Steam;../src/effect;../src/Engine;../src/ZLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\Inc;..\src\lib\Steam;../src/effect;../src/_Utility;../src/Engine;../src/ZLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;DEBUG;SRVLOG;WIN32;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/src/WinTrek/WinTrek.cpp
+++ b/src/WinTrek/WinTrek.cpp
@@ -25,6 +25,8 @@ class QuickChatNode : public IMDLObject {};
 #include <D3DDevice9.h>
 #include <DX9PackFile.h>
 
+#include "FileLoader.h"
+
 // Tell the linker that my DLL should be delay loaded
 //#pragma comment(linker, "/DelayLoad:icqmapi.dll")
 
@@ -2758,9 +2760,19 @@ public:
 		debugf("Setting art path to: %s\n", (PCC) strArtPath);
 
 		// Now set the art path, performed after initialise, else Modeler isn't valid.
-		GetModeler()->SetArtPath(strArtPath);
 
-        UiEngine::SetGlobalArtPath((std::string)strArtPath);
+        auto pFileLoader = CreateSecureFileLoader(
+        {
+            strArtPath + "/Textures",
+            strArtPath
+        },
+            strArtPath
+        );
+        GetModeler()->SetFileLoader(pFileLoader);
+
+        GetModeler()->SetArtPath(strArtPath); //todo remove
+
+        UiEngine::SetGlobalFileLoader(pFileLoader);
 
         if (g_bLuaDebug) {
             UiEngine::m_stringLogPath = (std::string)"lua.log";

--- a/src/WinTrek/WinTrek.cpp
+++ b/src/WinTrek/WinTrek.cpp
@@ -2759,13 +2759,33 @@ public:
 
 		debugf("Setting art path to: %s\n", (PCC) strArtPath);
 
-		// Now set the art path, performed after initialise, else Modeler isn't valid.
 
-        auto pFileLoader = CreateSecureFileLoader(
+        std::vector<ZString> vArtPaths;
         {
-            strArtPath + "/Textures",
-            strArtPath
-        },
+            //Go through the mod directory and add each directory in there
+
+            std::string search_path = "./Mods/*";
+            WIN32_FIND_DATA fd;
+            HANDLE hFind = ::FindFirstFile(search_path.c_str(), &fd);
+            if (hFind != INVALID_HANDLE_VALUE) {
+                do {
+                    if ((fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && fd.cFileName[0] != '.') {
+                        vArtPaths.push_back(ZString("./Mods/") + fd.cFileName);
+                    }
+                } while (::FindNextFile(hFind, &fd));
+                ::FindClose(hFind);
+            }
+        }
+
+        //old and deprecated highres directory
+        vArtPaths.push_back(strArtPath + "/Textures");
+
+        //main artwork directory
+        vArtPaths.push_back(strArtPath);
+
+        // Now set the art path, performed after initialise, else Modeler isn't valid.
+        auto pFileLoader = CreateSecureFileLoader(
+            vArtPaths,
             strArtPath
         );
         GetModeler()->SetFileLoader(pFileLoader);

--- a/src/WinTrek/WinTrek.cpp
+++ b/src/WinTrek/WinTrek.cpp
@@ -1348,7 +1348,6 @@ public:
     TRef<IMenuItem>            m_pitemToggleStars;
     TRef<IMenuItem>            m_pitemToggleEnvironment;
     TRef<IMenuItem>			   m_pitemToggleUseOldUi;
-	TRef<IMenuItem>			   m_pitemToggleHighResTextures; // BT - 10/17 - HighRes Textures
     TRef<IMenuItem>            m_pitemToggleRoundRadar;
     TRef<IMenuItem>            m_pitemToggleLinearControls;
     TRef<IMenuItem>            m_pitemToggleLargeDeadZone;
@@ -1456,9 +1455,6 @@ public:
     HWND  m_hwndVTEdit;
 
     bool m_bUseOldUi;
-
-	// BT - 10/17 - HighRes Textures
-	bool m_bUseHighResTextures;
 
     //
     // Input
@@ -2743,7 +2739,6 @@ public:
 		m_iMouseAccel(0), //#215
 		m_bShowInventoryPane(true), // BT - 10/17 - Map and Sector Panes are now shown on launch and remember the pilots settings on last dock. 
 		m_bShowSectorMapPane(true),  // BT - 10/17 - Map and Sector Panes are now shown on launch and remember the pilots settings on last dock. 
-		m_bUseHighResTextures(true), // BT - 10/17 - HighRes Textures
         m_bUseOldUi(false)
     {
         HRESULT hr;
@@ -2790,7 +2785,7 @@ public:
         );
         GetModeler()->SetFileLoader(pFileLoader);
 
-        GetModeler()->SetArtPath(strArtPath); //todo remove
+        GetModeler()->SetArtPath(strArtPath); //some functionality relies on the artpath
 
         UiEngine::SetGlobalFileLoader(pFileLoader);
 
@@ -3058,11 +3053,6 @@ public:
         m_bFFAutoCenter			 = (LoadPreference("FFAutoCenter",			0) != 0); //Imago #187
 		m_iMouseAccel			 = LoadPreference("MouseAcceleration",     0) % 3; // Imago #215 //#282 bugfix
 		m_iWheelDelay			 = LoadPreference("WheelDelay",            2) % 5; //Spunky #282
-
-		// BT - 10/17 - HighRes Textures
-		m_bUseHighResTextures    = (LoadPreference("HighResTextures",		1) != 0);
-
-		m_pmodeler->SetHighResTextures(m_bUseHighResTextures);
 
         m_bUseOldUi = (LoadPreference("OldUi", 1) != 0);
 
@@ -4181,8 +4171,6 @@ public:
 	#define idmMouseAccel		820
 	#define idmWheelDelay		821 //Spunky #282
 
-	#define idmHighResTextures	822	// BT - 10/17 - HighRes Textures
-
     #define idmOldUi	        823
 
 	// BT - STEAM
@@ -4698,9 +4686,6 @@ public:
                 m_pitemToggleLensFlare             = pmenu->AddMenuItem(idmToggleLensFlare,             GetLensFlareMenuString()            ,	'F');
                 m_pitemToggleBidirectionalLighting = pmenu->AddMenuItem(idmToggleBidirectionalLighting, GetBidirectionalLightingMenuString(),	'B');
                 m_pitemStyleHUD                    = pmenu->AddMenuItem(idmStyleHUD,                    GetStyleHUDMenuString()             ,	'H'); //Imago 6/30/09 adjust new dx9 settings in game
-				
-				// BT - 10/17 - HighRes Textures
-				m_pitemToggleHighResTextures	   = pmenu->AddMenuItem(idmHighResTextures,				GetHighResTexturesString(),				'X');
 
                 //Rock: Disabled for release
                 //m_pitemToggleUseOldUi     = pmenu->AddMenuItem(idmOldUi, GetOldUiMenuString(), 'G');
@@ -5487,25 +5472,6 @@ public:
 
     }
 
-	// BT - 10/17 - HighRes Textures
-	void ToggleHighResTextures()
-	{
-		m_bUseHighResTextures = !m_bUseHighResTextures;
-
-		SavePreference("HighResTextures", m_bUseHighResTextures);
-
-		GetWindow()->GetModeler()->SetHighResTextures(m_bUseHighResTextures);
-
-		if (m_pitemToggleHighResTextures != NULL) {
-			m_pitemToggleHighResTextures->SetString(GetHighResTexturesString());
-		}
-
-		m_pmessageBox = CreateMessageBox("Enabling or Disabling the High Resolution Textures will require you to restart Allegiance.", NULL, true, false);
-        m_pmessageBox->GetEventSource()->AddSink(new CloseNotificationSink(this));
-		GetWindow()->GetPopupContainer()->OpenPopup(m_pmessageBox, false);
-
-	}
-
 	//Imago 7/8/09 #24
     void ToggleShowGrid()
     {
@@ -6169,12 +6135,6 @@ public:
         return "Use old UI: " + ZString(m_bUseOldUi ? "On" : "Off");
     }
 
-	// BT - 10/17 - HighRes Textures
-	ZString GetHighResTexturesString()
-	{
-		return "Use High Resolution Textures: " + ZString(m_bUseHighResTextures ? "On" : "Off");
-	}
-
     ZString GetEnableFeedbackMenuString()
     {
         return (m_bEnableFeedback ? "Force Feedback Enabled " : "Force Feedback Disabled ");
@@ -6448,11 +6408,6 @@ public:
             case idmToggleEnvironment:
                 ToggleEnvironment();
                 break;
-
-				// BT - 10/17 - HighRes Textures
-			case idmHighResTextures:
-				ToggleHighResTextures();
-				break;
 
             case idmOldUi:
                 ToggleOldUi();

--- a/src/WinTrek/mappvmaker.cpp
+++ b/src/WinTrek/mappvmaker.cpp
@@ -2345,7 +2345,7 @@ const char * CmapPVMakerFromIGCFile::GenerateMission(const char * igcfile,	Imiss
     Modeler* pmodeler = pmission->GetModeler();
 
 	// BT - 10/17 - HighRes Textures
-	TRef<ZFile> zf = pmodeler->GetFile(igcfile,"igc",false, pmodeler->GetUseHighResTextures());
+	TRef<ZFile> zf = pmodeler->GetFile(igcfile,"igc",false);
     
 	if (!zf) return "no preview available";
 

--- a/src/WinTrek/treksound.cpp
+++ b/src/WinTrek/treksound.cpp
@@ -36,13 +36,17 @@ public:
 		// mdvalley: Look for files in this order: Soundpack WAV, Soundpack OGG, Artwork WAV, Artwork OGG
         // pkk: Removed SoundPack support, Allegiance no longer looking for files in a not existing folder
 		// Load wave from artwork directory
-        ZString strFilename = m_pmodeler->GetArtPath() + "\\..\\" + pstring->GetValue() + ".wav";
-		
-		if (!FileExists(strFilename))
-		{
-		    // Load ogg file, if wave file doesn't exisits
-			strFilename = m_pmodeler->GetArtPath() + "\\" + pstring->GetValue() + ".ogg";
-		}
+
+        auto loader = m_pmodeler->GetFileLoader();
+        ZString strFilename = "";
+
+        if (loader->HasFile(pstring->GetValue() + ".wav")) {
+            strFilename = loader->GetFilePath(pstring->GetValue() + ".wav");
+        }
+        else if (loader->HasFile(pstring->GetValue() + ".ogg")) {
+            // Load ogg file, if wave file doesn't exists
+            strFilename = loader->GetFilePath(pstring->GetValue() + ".ogg");
+        }
 		
         if (FAILED(CreateWaveFileSoundTemplate(pTemplate, strFilename)))
         {

--- a/src/_Utility/FileLoader.cpp
+++ b/src/_Utility/FileLoader.cpp
@@ -1,0 +1,140 @@
+#include "pch.h"
+
+#include "FileLoader.h"
+
+#ifdef STEAMSECURE
+#include "steam_api.h"
+#include <AllegianceSecurity.h>
+#endif
+
+void ExitWithError(const char* message) {
+    PostMessageA(GetActiveWindow(), WM_SYSCOMMAND, SC_MINIMIZE, 0);
+
+    MessageBoxA(GetDesktopWindow(), message, "Allegiance: Fatal modeler error", MB_ICONERROR);
+
+    exit(0);
+}
+
+class FileLoader : public IFileLoader {
+private:
+    std::vector<ZString> m_vPaths;
+public:
+
+    FileLoader(const std::vector<ZString>& vPaths) :
+        m_vPaths(vPaths)
+    {}
+
+    bool HasFile(const ZString& path) {
+        TRef<ZFile> file;
+
+        for (auto entry : m_vPaths) {
+            file = new ZFile(entry + "/" + path, OF_READ | OF_SHARE_DENY_WRITE);
+            if (file->IsValid()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    ZString GetFilePath(const ZString& path) {
+        TRef<ZFile> file;
+
+        for (auto entry : m_vPaths) {
+            file = new ZFile(entry + "/" + path, OF_READ | OF_SHARE_DENY_WRITE);
+            if (file->IsValid()) {
+                return entry + "/" + path;
+            }
+        }
+
+        ExitWithError("Artwork file could not be opened: " + path + ".");
+        return "";
+    }
+
+    TRef<ZFile> GetFile(const ZString& path) {
+        TRef<ZFile> file;
+
+        for (auto entry : m_vPaths) {
+            file = new ZFile(entry + "/" + path, OF_READ | OF_SHARE_DENY_WRITE);
+            if (file->IsValid()) {
+                return file;
+            }
+        }
+
+        ExitWithError("Artwork file could not be opened: " + path + ".");
+        return nullptr;
+    }
+};
+
+#ifdef STEAMSECURE
+class SteamSecureFileLoader : public IFileLoader {
+    FileHashTable			m_fileHashTable;
+
+    std::shared_ptr<IFileLoader> m_loaderInner;
+    ZString m_pathSecure;
+
+    TRef<ZFile> Verify(const ZString& path) {
+        ZString fullPath = m_pathSecure + "/" + path;
+        TRef<ZFile> file = new ZFile(fullPath, OF_READ | OF_SHARE_DENY_WRITE);
+
+        if (file->IsValid() == false || m_fileHashTable.IsHashCorrect(path, file) == false) {
+            // BT - STEAM - Queue up a full content re-verify in case the user has a corrupted file.
+            if (SteamUser() != nullptr && SteamUser()->BLoggedOn() == true) {
+                SteamApps()->MarkContentCorrupt(false);
+            }
+
+            ExitWithError("Artwork file failed to validate: " + fullPath + ", we have queued up an installation reverification. Check your Steam App in the downloads section for details.");
+
+            return nullptr;
+        }
+
+        return file;
+    }
+
+public:
+    SteamSecureFileLoader(const std::shared_ptr<IFileLoader>& inner, const ZString& pathSecure) :
+        m_loaderInner(inner),
+        m_pathSecure(pathSecure)
+    {}
+
+    bool HasFile(const ZString& path) {
+        if (m_fileHashTable.DoesFileHaveHash(path)) {
+            TRef<ZFile> file = Verify(path);
+            return true;
+        }
+
+        return m_loaderInner->HasFile(path);
+    }
+
+    ZString GetFilePath(const ZString& path) {
+        if (m_fileHashTable.DoesFileHaveHash(path)) {
+            TRef<ZFile> file = Verify(path);
+            return m_pathSecure + "/" + path;
+        }
+
+        return m_loaderInner->GetFilePath(path);
+    }
+
+    TRef<ZFile> GetFile(const ZString& path) {
+        if (m_fileHashTable.DoesFileHaveHash(path)) {
+            TRef<ZFile> file = Verify(path);
+            return file;
+        }
+
+        return m_loaderInner->GetFile(path);
+    }
+};
+#endif
+
+std::shared_ptr<IFileLoader> CreateFileLoader(const std::vector<ZString>& vPaths) {
+    return std::make_shared<FileLoader>(vPaths);
+}
+
+std::shared_ptr<IFileLoader> CreateSecureFileLoader(const std::vector<ZString>& vPaths, const ZString& pathSecure) {
+    std::shared_ptr<IFileLoader> loader = CreateFileLoader(vPaths);
+
+    #ifdef STEAMSECURE
+    loader = std::make_shared<SteamSecureFileLoader>(loader, pathSecure);
+    #endif
+
+    return loader;
+}

--- a/src/_Utility/FileLoader.h
+++ b/src/_Utility/FileLoader.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "tref.h"
+#include "base.h"
+#include "vector"
+#include "memory"
+
+class IFileLoader {
+public:
+
+    virtual bool HasFile(const ZString& path) = 0;
+    virtual ZString GetFilePath(const ZString& path) = 0;
+    virtual TRef<ZFile> GetFile(const ZString& path) = 0;
+};
+
+std::shared_ptr<IFileLoader> CreateSecureFileLoader(const std::vector<ZString>& vPaths, const ZString& pathSecure);

--- a/src/engine/model.h
+++ b/src/engine/model.h
@@ -248,7 +248,7 @@ public:
     virtual std::shared_ptr<IFileLoader>         GetFileLoader() = 0;
 
     // KGJV 32B - move this to abstrat class modeler
-    virtual TRef<ZFile> GetFile(const PathString& pathStr, const ZString& strExtensionArg, bool bError, bool getHighresVersion) = 0; // BT - 10/17 - HighRes Textures
+    virtual TRef<ZFile> GetFile(const PathString& pathStr, const ZString& strExtensionArg, bool bError) = 0;
 
     virtual INameSpace*     CreateNameSpace(const ZString& str)                        = 0;
     virtual INameSpace*     CreateNameSpace(const ZString& str, INameSpace* pnsParent) = 0;
@@ -256,11 +256,7 @@ public:
     virtual void            UnloadNameSpace(const ZString& str)                        = 0;
     virtual void            UnloadNameSpace(INameSpace* pns)                           = 0;
 
-	// BT - 10/17 - HighRes Textures
-	virtual void			SetHighResTextures(bool m_bUseHighResTextures) = 0;
-	virtual bool			GetUseHighResTextures() = 0;
-
-    virtual TRef<ZFile>     LoadFile(const PathString& pathStr, const ZString& strExtensionArg, bool bError = true, bool useHighres = true)                 = 0; // BT - 10/17 - HighRes Textures
+    virtual TRef<ZFile>     LoadFile(const PathString& pathStr, const ZString& strExtensionArg, bool bError = true)                 = 0;
     virtual HBITMAP         LoadBitmap(const PathString& pathStr, bool bError = true)               = 0;
     virtual TRef<Image>     LoadImage(const ZString& pathStr, bool bColorKey, bool bError = true, bool bSystemMem = false )   = 0;
     virtual TRef<Surface>   LoadSurface(const ZString& pathStr, bool bColorKey, bool bError = true, bool bSystemMem = false ) = 0;

--- a/src/engine/model.h
+++ b/src/engine/model.h
@@ -1,6 +1,8 @@
 #ifndef _Model_h_
 #define _Model_h_
 
+#include <memory>
+
 #include "bounds.h"
 #include "context.h"
 #include "value.h"
@@ -8,6 +10,8 @@
 #include <input.h>
 #include <tref.h>
 #include <tvector.h>
+
+#include "FileLoader.h"
 
 class Context;
 class D3DVertex;
@@ -235,7 +239,8 @@ public:
     // Modeler members
     //
 
-    virtual void            SetSite(ModelerSite* psite) = 0;
+    virtual void            SetSite(ModelerSite* psite) = 0; 
+    virtual void SetFileLoader(const std::shared_ptr<IFileLoader>& loader) = 0;
     virtual void            SetArtPath(const PathString& pathStr) = 0;
 
     virtual Engine*         GetEngine() = 0;

--- a/src/engine/model.h
+++ b/src/engine/model.h
@@ -245,6 +245,7 @@ public:
 
     virtual Engine*         GetEngine() = 0;
     virtual ZString         GetArtPath() = 0;
+    virtual std::shared_ptr<IFileLoader>         GetFileLoader() = 0;
 
     // KGJV 32B - move this to abstrat class modeler
     virtual TRef<ZFile> GetFile(const PathString& pathStr, const ZString& strExtensionArg, bool bError, bool getHighresVersion) = 0; // BT - 10/17 - HighRes Textures

--- a/src/engine/modeler.cpp
+++ b/src/engine/modeler.cpp
@@ -2188,6 +2188,11 @@ public:
         m_pathStr = pathStr;
     }
 
+    std::shared_ptr<IFileLoader> GetFileLoader()
+    {
+        return m_pFileLoader;
+    }
+
     ZString GetArtPath()
     {
         return m_pathStr;

--- a/src/engine/modeler.cpp
+++ b/src/engine/modeler.cpp
@@ -638,8 +638,7 @@ public:
         ZString  str    = GetString((IObject*)stack.Pop());
         bool     b      = GetBoolean((IObject*)stack.Pop());
 
-		// BT - 10/17 - HighRes Textures
-        TRef<ZFile> zf = m_pmodeler->GetFile(str,"",true, m_pmodeler->GetUseHighResTextures());
+        TRef<ZFile> zf = m_pmodeler->GetFile(str,"",true);
 		ZFile * pFile = (ZFile*) zf;
 		
 		D3DXIMAGE_INFO fileInfo;
@@ -2158,13 +2157,11 @@ private:
 	bool					m_bHintColorKey;			// Surface requires colour keying.
 	bool					m_bHintSystemMemory;
 	bool					m_bHintUIImage;
-	bool					m_bUseHighResTextures;
 
 public:
     ModelerImpl(Engine* pengine) :
         m_pengine(pengine),
-        m_pathStr("."),
-		m_bUseHighResTextures(true) // BT - 10/17 - HighRes Textures
+        m_pathStr(".")
 		{
         m_psite = new ModelerSiteImpl();
         InitializeNameSpace();
@@ -2422,19 +2419,7 @@ public:
         return m_pengine;
 	}
 
-	// BT - 10/17 - HighRes Textures
-	void SetHighResTextures(bool bUseHighResTextures)
-	{
-		m_bUseHighResTextures = bUseHighResTextures;
-	}
-
-	// BT - 10/17 - HighRes Textures
-	bool GetUseHighResTextures()
-	{
-		return m_bUseHighResTextures;
-	}
-
-	TRef<ZFile> GetFile(const PathString& pathStr, const ZString& strExtensionArg, bool bError, bool getHighresVersion)
+	TRef<ZFile> GetFile(const PathString& pathStr, const ZString& strExtensionArg, bool bError)
 	{
         ZString strExtension = pathStr.GetExtension();
         ZString strToOpen = pathStr;
@@ -2451,10 +2436,9 @@ public:
         return m_pFileLoader->GetFile(strToOpen);
 	}
 
-	// BT - 10/17 - HighRes Textures
-    TRef<ZFile> LoadFile(const PathString& pathStr, const ZString& strExtensionArg, bool bError, bool highRes)
+    TRef<ZFile> LoadFile(const PathString& pathStr, const ZString& strExtensionArg, bool bError)
     {
-        return GetFile(pathStr, strExtensionArg, bError, highRes);
+        return GetFile(pathStr, strExtensionArg, bError);
     }
 
 
@@ -2491,11 +2475,7 @@ public:
         // Is the image already loaded?
         //
 
-		// BT - 10/17 - HighRes Textures
 		ZString namespaceName = str;
-
-		if (m_bUseHighResTextures == true)
-			namespaceName += "-highres";
 
         TRef<INameSpace> pns = GetCachedNameSpace(namespaceName);
 
@@ -2575,7 +2555,7 @@ public:
         bool& bAnimation,
         bool bError
     ) {
-        TRef<ZFile> pfile = GetFile(pathStr, "x", bError, false); // BT - 10/17 - HighRes Textures
+        TRef<ZFile> pfile = GetFile(pathStr, "x", bError);
 
         if (pfile) {
             return ::ImportXFile(this, pfile, pnumberFrame, bAnimation);
@@ -2615,34 +2595,17 @@ public:
 	
     INameSpace* GetNameSpace(const ZString& str, bool bError, bool bSystemMem)
     {
-		// BT - 10/17 - HighRes Textures
 		TRef<INameSpace> pns;
 		
 		ZString namespaceName = str;
 
-		// if it's something that could have a high-res version...
-		if (str.Right(3) == "bmp")
-		{
-			if (m_bUseHighResTextures == true)
-			{
-				namespaceName += "-highres";
-				pns = GetCachedNameSpace(str + "-highres");
-			}
-			else
-			{
-				pns = GetCachedNameSpace(str);
-			}
-		}
-		else
-		{
-			pns = GetCachedNameSpace(str);
-		}
+        pns = GetCachedNameSpace(str);
 
 		if (pns)
 			return pns;
 
 
-		TRef<ZFile> pfile = GetFile(str, "mdl", bError, m_bUseHighResTextures);
+		TRef<ZFile> pfile = GetFile(str, "mdl", bError);
 
 
 		if (pfile != NULL)

--- a/src/mdlc/mdlc.cpp
+++ b/src/mdlc/mdlc.cpp
@@ -169,7 +169,7 @@ public:
        // TRef<Surface> psurface = GetEngine()->CreateSurface(hbitmap);
         //ZVerify(::DeleteObject(hbitmap));
 		
-		TRef<ZFile> zf = GetModeler()->GetFile(strInput,"",false, GetModeler()->GetUseHighResTextures());
+		TRef<ZFile> zf = GetModeler()->GetFile(strInput,"",false);
 		ZFile * pFile = (ZFile*) zf;
 		D3DXIMAGE_INFO fileInfo;
 		D3DXGetImageInfoFromFileInMemory(pFile->GetPointer(),pFile->GetLength(),&fileInfo );

--- a/src/mdledit/mdledit.cpp
+++ b/src/mdledit/mdledit.cpp
@@ -753,7 +753,7 @@ public:
     {
         //TRef<Surface> psurface = GetModeler()->LoadSurface("fxminebmp", true);
 
-		TRef<ZFile> zf = m_pmodeler->GetFile("fxmine.png","",true, m_pmodeler->GetUseHighResTextures());
+		TRef<ZFile> zf = m_pmodeler->GetFile("fxmine.png","",true);
 
 	ZFile * pFile = (ZFile*) zf;
 		

--- a/src/ui/UiEngine.h
+++ b/src/ui/UiEngine.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "FileLoader.h"
+
 class UiScreenConfiguration : public UiObjectContainer {
 public:
     UiScreenConfiguration(std::map<std::string, std::shared_ptr<Exposer>> map) :
@@ -16,13 +18,13 @@ class UiEngine : public IObject
 {
 protected:
 
-    static std::string m_stringArtPath;
+    static std::shared_ptr<IFileLoader> m_fileLoader;
 
 public:
 
     static std::string m_stringLogPath;
 
-    static void SetGlobalArtPath(std::string path);
+    static void SetGlobalFileLoader(const std::shared_ptr<IFileLoader>& pLoader);
     static UiEngine* UiEngine::Create(Window* pWindow, Engine* pEngine, ISoundEngine* pSoundEngine, std::function<void(std::string)> funcOpenWebsite);
 
     //virtual Image* LoadImage(std::string path) = 0;
@@ -63,11 +65,11 @@ class LuaScriptContext;
 class Loader {
 
 private:
-    PathFinder m_pathfinder;
     sol::state* m_pLua;
+    std::shared_ptr<IFileLoader> m_pFileLoader;
 
 public:
-    Loader(sol::state& lua, Engine* pEngine, std::vector<std::string> paths);
+    Loader(sol::state& lua, Engine* pEngine, const std::shared_ptr<IFileLoader>& pFileLoader);
     ~Loader();
 
     void InitNamespaces(LuaScriptContext& context);
@@ -98,7 +100,7 @@ private:
     TRef<Engine> m_pEngine;
     TRef<ISoundEngine> m_pSoundEngine;
     Loader m_loader;
-    PathFinder m_pathFinder;
+    std::shared_ptr<IFileLoader> m_pFileLoader;
     std::shared_ptr<UiScreenConfiguration> m_pConfiguration;
     std::function<void(std::string)> m_funcOpenWebsite;
     TRef<SimpleModifiableValue<bool>> m_pHasKeyboardFocus;
@@ -115,7 +117,7 @@ public:
         Window* pWindow,
         Engine* pEngine,
         ISoundEngine* pSoundEngine, 
-        std::string stringArtPath, 
+        const std::shared_ptr<IFileLoader>& pFileLoader,
         const std::shared_ptr<UiScreenConfiguration>& pConfiguration, 
         std::function<void(std::string)> funcOpenWebsite
     );


### PR DESCRIPTION
This attempts to improve the modding situation.

Currently, the game structure looks like this:
```
Artwork
  Textures
    highresartwork.png
  standardfile.png
  othermoddedfile.png
Allegiance.exe
```

With this PR I want to change it to
```
Artwork
  standardfile.png
  otherstandardfile.png
Mods
  OfficialTexturePack
    highresartwork.png
  SomeOtherMod
    reticle.png
Allegiance.exe
```

This is implemented by a list of "ArtPaths". It first checks the directories inside "./Mods", and if not found it checks the default artwork directory. With this solution, there should never be a reason for a user to overwrite files in the default artwork directory.

If a file needs to be verified, it skips all the mod directories and only uses the one in the default artwork.