### PR TITLE
Random Xynth

### DIFF
--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -10885,7 +10885,7 @@ class ThingSiteImpl : public ThingSite
 										sv.fVisible(true);
 										sv.CurrentEyed(true); //Xynth #100 7/2010
 
-                                        //Xynth: something was just seen, I want to know if it was a probe that saw it and if this was high value target; Radulfr: You also want to turn it into a ship, so ignore if it isn't one
+                                        //Check for spotted high value targets and award achievements/score -- Not going to work for as intended with more than 2 teams; Why does spotting with probes give points, spotting with a ship not?
                                         if (pmodel->GetObjectType() == OT_ship)
                                         {
                                             IshipIGC* pSpottedShip = (IshipIGC*)pmodel;

--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -10886,38 +10886,33 @@ class ThingSiteImpl : public ThingSite
 										sv.CurrentEyed(true); //Xynth #100 7/2010
 
                                         //Check for spotted high value targets and award achievements/score -- Not going to work for as intended with more than 2 teams; Why does spotting with probes give points, spotting with a ship not?
-                                        if (pmodel->GetObjectType() == OT_ship)
-                                        {
+                                        if (pmodel->GetObjectType() == OT_ship) {
                                             IshipIGC* pSpottedShip = (IshipIGC*)pmodel;
-                                            if (pSpottedShip)
-                                            {
-                                                if (s->GetObjectType() == OT_probe && pSpottedShip->GetHullType() != nullptr && pSpottedShip->GetHullType()->GetData() != nullptr)
-                                                {
-                                                    AssetMask am = GetAssetMask(pSpottedShip, pSpottedShip->GetHullType(), false);
-                                                    short hvMask = c_amEnemyMiner | c_amEnemyBuilder | c_amEnemyCapital | c_amEnemyCarrier | c_amEnemyBomber | c_amEnemyAPC | c_amEnemyTeleportShip;
-                                                    if (am & hvMask)
-                                                    {
-                                                        ObjectID probeID = s->GetObjectID();
-                                                        ImodelIGC * pProbeModel = s->GetMission()->GetModel(OT_probe, probeID);
-                                                        IprobeIGC * pProbe = (IprobeIGC*)pProbeModel;
-                                                        if (pProbe && !pSpottedShip->PreviouslySpotted())
-                                                        {
+                                            if (pSpottedShip && pSpottedShip->GetHullType()->GetData()) { // Guard for exploding ship without data
+                                                AssetMask spottedMask = GetAssetMask(pSpottedShip, pSpottedShip->GetHullType(), false);
+                                                const short hvMask = c_amEnemyMiner | c_amEnemyBuilder | c_amEnemyCapital | c_amEnemyCarrier | c_amEnemyBomber | c_amEnemyAPC | c_amEnemyTeleportShip;
+                                                if (spottedMask & hvMask) {
+                                                    if (s->GetObjectType() == OT_probe) {
+                                                        IprobeIGC* pProbe = (IprobeIGC*)s;
+                                                        if (!pSpottedShip->PreviouslySpotted()) {
                                                             IshipIGC* pProbingShip = pProbe->GetProbeLauncherShip();
-                                                            if (pProbingShip)
-                                                            {
-                                                                CFSShip* pfsShip = (CFSShip *)(pProbingShip->GetPrivateData());
-                                                                if (pfsShip && pfsShip->IsPlayer())
-                                                                {
-                                                                    CFSPlayer* pfsPlayer = pfsShip->GetPlayer();
-                                                                    if (pfsPlayer)
-                                                                    {
-                                                                        PlayerScoreObject * pso = pfsShip->GetPlayerScoreObject();
-                                                                        if (pso)
-                                                                            pso->AddProbeSpot();
-                                                                        pfsPlayer->GetSteamAchievements()->AwardIGCAchievements(c_achmProbeSpot);
-                                                                    }
-                                                                }
+                                                            if (pProbingShip && pProbingShip->GetPilotType() == c_ptPlayer) {
+                                                                CFSShip* pfsShip = (CFSShip*)(pProbingShip->GetPrivateData());
+                                                                PlayerScoreObject * pso = pfsShip->GetPlayerScoreObject();
+                                                                debugf("Adding spotting score by probe.");
+                                                                pso->AddProbeSpot();
+                                                                if (pfsShip->IsPlayer())
+                                                                    pfsShip->GetPlayer()->GetSteamAchievements()->AwardIGCAchievements(c_achmProbeSpot);
                                                             }
+                                                        }
+                                                    }
+                                                    else if (s->GetObjectType() == OT_ship) {
+                                                        IshipIGC* spottingShip = (IshipIGC*)s;
+                                                        if (spottingShip->GetPilotType() == c_ptPlayer) {
+                                                            CFSShip* pfsShip = (CFSShip*)(spottingShip->GetPrivateData());
+                                                            PlayerScoreObject * pso = pfsShip->GetPlayerScoreObject();
+                                                            debugf("Adding spotting score by ship.");
+                                                            pso->AddProbeSpot();
                                                         }
                                                     }
                                                 }

--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -1169,12 +1169,14 @@ void SetCharStats(int                   characterID,
 	debugf("CharacterID=%d, Rank=%d, bScoresCount=%d, CivID=%d, Rating=%d,\n",
         characterID, Rank ,pfsMission->GetScoresCount(), pSide->GetCivilization()->GetObjectID(),
 		RATING_INT2EXT(pso.GetCombatRating()));
-    debugf("    WarpsSpotted=%.2f, AsteroidsSpotted=%.2f, TechsRecovered=%.2f,\n",
+    debugf("    WarpsSpotted=%.2f, AsteroidsSpotted=%.2f, TechsRecovered=%d,\n",
         pso.GetWarpsSpotted(), pso.GetAsteroidsSpotted(), pso.GetTechsRecovered());
     debugf("    MinerKills=%.2f, BuilderKills=%.2f, LayerKills=%.2f, PlayerKills=%.2f,\n",
         pso.GetMinerKills(), pso.GetBuilderKills(), pso.GetLayerKills(), pso.GetPlayerKills());
     debugf("    BaseKills=%.2f, BaseCaptures=%.2f, Deaths=%d, PilotBaseKills=%d, BaseCaptures=%d,\n",
         pso.GetBaseKills(), pso.GetBaseCaptures(), pso.GetDeaths(), pso.GetPilotBaseKills(), pso.GetPilotBaseCaptures());
+    debugf("    HighValueTargetsSpotted=%d, Repair=%.2f,\n",
+        pso.GetTargetsSpotted(), pso.GetRepair());
     debugf("    Minutes=%.2f, bWin=%d, bLose=%d, bWinCmd=%d, bLoseCmd=%d, Score=%.2f.\n",
         (pso.GetTimePlayed() / 60.0f), pso.GetWinner(), pso.GetLoser(), pso.GetCommandWinner(), pso.GetCommandLoser(),
 		pso.GetScore());
@@ -10819,49 +10821,36 @@ class ThingSiteImpl : public ThingSite
                     assert (sid < c_cSidesMax);
 
                     SideVisibility& sv = m_rgSideVisibility[sid];
-
+                    bool seenBefore = sv.fVisible();
 
                     //Update the visibility for everything except visible static objects
-                    //if (!(m_bPredictable && sv.fVisible()))  Xynth #100 We need to check vis on everything to get Currenteye
-					bool staticVisible = m_bPredictable && sv.fVisible(); //Xynth#100 keep track of static visibles
-					//{
-                        if (pside == pmodel->GetSide() && !pmodel->SeenBySide(pside)) //ALLY imago 7/7/09 Visibility 7/11/09
-                        {
+                        if (seenBefore && m_bPredictable) {
+                            //no need to change anything
+                        }
+                        else if (pside == pmodel->GetSide()) {
                             //Always see object on your own side (& call ShowObject() to export new stations, etc.)
-                            sv.fVisible(true);
-							sv.CurrentEyed(true); //Xynth #100 7/2010
-                            ShowObject(pside, pmodel);
-
-
-						} else if (pside->AlliedSides(pside,pmodel->GetSide()) && pside->GetMission()->GetMissionParams()->bAllowAlliedViz && !pmodel->SeenBySide(pside)) {
-										//printf("show object to ally via model's side\n");
-										//Allies See it
-                            			sv.fVisible(true);
-										sv.CurrentEyed(true); //Xynth #100 7/2010
-										ShowObject(pside, pmodel);
-			
-						} else if (sv.pLastSpotter() && sv.pLastSpotter()->InScannerRange(pmodel) && !pmodel->SeenBySide(pside)) // ALLY SCAN 7/11/09 Imago
-						{						
-	                            if (!sv.fVisible())
-	                            {
-	                                //See it
-	                                sv.fVisible(true);									
-	                                ShowObject(pside, pmodel);
-	                            }
-								sv.CurrentEyed(true); //Xynth #100 7/2010
-
-						} else if (sv.pLastSpotter() && pside->AlliedSides(pside,sv.pLastSpotter()->GetSide()) && sv.pLastSpotter()->InScannerRange(pmodel) && pside->GetMission()->GetMissionParams()->bAllowAlliedViz && !pmodel->SeenBySide(pside)) {
-	                            if (!sv.fVisible())
-	                            {
-	                                //Allies See it
-									//printf("show object to ally via last spotter's side\n");
-	                                sv.fVisible(true);									
-	                                ShowObject(pside, pmodel);
-	                            }
-								sv.CurrentEyed(true); //Xynth #100 7/2010
+                            if (!seenBefore) {
+                                sv.fVisible(true);
+                                sv.CurrentEyed(true);
+                                ShowObject(pside, pmodel);
+                            }
+						} 
+                        else if (pside->AlliedSides(pside,pmodel->GetSide()) && pside->GetMission()->GetMissionParams()->bAllowAlliedViz) {
+							//Allies See it
+                            if (!seenBefore) {
+                                sv.fVisible(true);
+                                sv.CurrentEyed(true);
+                                ShowObject(pside, pmodel);
+                            }
+						} 
+                        else if (sv.pLastSpotter() && sv.pLastSpotter()->InScannerRange(pmodel)) { // No need to check if sv.pLastSpotter is allied, as only those get set as sv.pLastSpotter
+                            if (!seenBefore) {
+                                sv.fVisible(true);
+                                sv.CurrentEyed(true);
+                                ShowObject(pside, pmodel);
+                            }
 						}
-                        else
-						{
+                        else {
                             //Not trivially seen ... loop over everything that could see it
                             sv.fVisible(false);
 							sv.CurrentEyed(false); //Xynth #100 7/2010
@@ -10877,51 +10866,49 @@ class ThingSiteImpl : public ThingSite
 
 									bool bSent = false;
                                     //See it
-									if (!pmodel->SeenBySide(pside)) {
-                                    	if (!staticVisible)  //Xynth #135 7/2010
-										{
-                                    		bSent = ShowObject(pside, pmodel);
-										}
-										sv.fVisible(true);
-										sv.CurrentEyed(true); //Xynth #100 7/2010
+                                    if (!seenBefore) {
+                                        bSent = ShowObject(pside, pmodel);
+                                        sv.fVisible(true);
+                                        sv.CurrentEyed(true); //Xynth #100 7/2010
 
-                                        //Check for spotted high value targets and award achievements/score -- Not going to work for as intended with more than 2 teams; Why does spotting with probes give points, spotting with a ship not?
+                                        //Check for spotted high value targets and award achievement/score
                                         if (pmodel->GetObjectType() == OT_ship) {
+                                            ObjectType t;
                                             IshipIGC* pSpottedShip = (IshipIGC*)pmodel;
+                                            //debugf("Ship %s spotted by %s.\n", GetModelName(pmodel), GetModelName(s));
                                             if (pSpottedShip && pSpottedShip->GetHullType()->GetData()) { // Guard for exploding ship without data
                                                 AssetMask spottedMask = GetAssetMask(pSpottedShip, pSpottedShip->GetHullType(), false);
                                                 const short hvMask = c_amEnemyMiner | c_amEnemyBuilder | c_amEnemyCapital | c_amEnemyCarrier | c_amEnemyBomber | c_amEnemyAPC | c_amEnemyTeleportShip;
                                                 if (spottedMask & hvMask) {
-                                                    if (s->GetObjectType() == OT_probe) {
-                                                        IprobeIGC* pProbe = (IprobeIGC*)s;
-                                                        if (!pSpottedShip->PreviouslySpotted()) {
+                                                    if (!pSpottedShip->RecentlySpotted()) {
+                                                        if (s->GetObjectType() == OT_probe) {
+                                                            IprobeIGC* pProbe = (IprobeIGC*)s;
                                                             IshipIGC* pProbingShip = pProbe->GetProbeLauncherShip();
-                                                            if (pProbingShip && pProbingShip->GetPilotType() == c_ptPlayer) {
+                                                            if (pProbingShip && pProbingShip->GetPilotType() >= c_ptPlayer) {
                                                                 CFSShip* pfsShip = (CFSShip*)(pProbingShip->GetPrivateData());
                                                                 PlayerScoreObject * pso = pfsShip->GetPlayerScoreObject();
-                                                                debugf("Adding spotting score by probe.");
-                                                                pso->AddProbeSpot();
+                                                                pso->AddTargetSpot();
                                                                 if (pfsShip->IsPlayer())
                                                                     pfsShip->GetPlayer()->GetSteamAchievements()->AwardIGCAchievements(c_achmProbeSpot);
                                                             }
                                                         }
-                                                    }
-                                                    else if (s->GetObjectType() == OT_ship) {
-                                                        IshipIGC* spottingShip = (IshipIGC*)s;
-                                                        if (spottingShip->GetPilotType() == c_ptPlayer) {
-                                                            CFSShip* pfsShip = (CFSShip*)(spottingShip->GetPrivateData());
-                                                            PlayerScoreObject * pso = pfsShip->GetPlayerScoreObject();
-                                                            debugf("Adding spotting score by ship.");
-                                                            pso->AddProbeSpot();
+                                                        else if (s->GetObjectType() == OT_ship) {
+                                                            IshipIGC* spottingShip = (IshipIGC*)s;
+                                                            if (spottingShip->GetPilotType() >= c_ptPlayer) {
+                                                                CFSShip* pfsShip = (CFSShip*)(spottingShip->GetPrivateData());
+                                                                PlayerScoreObject * pso = pfsShip->GetPlayerScoreObject();
+                                                                pso->AddTargetSpot();
+                                                            }
                                                         }
+                                                        //mark hv ship as previously spotted, no matter by whom
+                                                        pSpottedShip->MarkPreviouslySpotted();
                                                     }
                                                 }
-                                                //mark ship as previously spotted, no matter by whom
-                                                pSpottedShip->MarkPreviouslySpotted();
                                             }
                                         }
-									}
+                                    }
 									
+                                    //Show it to allies who don't see it
 									if (pside->GetMission()->GetMissionParams()->bAllowAlliedViz) //ALLY should be SCAN Imago 7/11/09
 									{
 										//lets get a list of allied sideIDs
@@ -10944,8 +10931,7 @@ class ThingSiteImpl : public ThingSite
 												ObjectType  otSpotter = s->GetObjectType();
 		                                        if (((bAllySent) && otModel == OT_station || otModel == OT_warp ||
 		                                            (otModel == OT_asteroid &&
-		                                             (static_cast<IasteroidIGC*>(pmodel)->GetCapabilities() & ~c_aabmBuildable) != 0))
-													 && !staticVisible) //Xynth #135 7/2010
+		                                             (static_cast<IasteroidIGC*>(pmodel)->GetCapabilities() & ~c_aabmBuildable) != 0)))
 												{
 
 	                                           		ObjectType  otSpotter = s->GetObjectType();
@@ -10960,7 +10946,8 @@ class ThingSiteImpl : public ThingSite
 												}
 											}
 										}
-									}									
+									}	
+
                                     //Keep track of who spotted it
                                     sv.pLastSpotter(s);
 
@@ -10970,8 +10957,7 @@ class ThingSiteImpl : public ThingSite
                                         ObjectType otModel = pmodel->GetObjectType();									
                                         if ((otModel == OT_station || otModel == OT_warp ||
                                             (otModel == OT_asteroid &&
-                                             (static_cast<IasteroidIGC*>(pmodel)->GetCapabilities() & ~c_aabmBuildable) != 0)) //Imago - Review - what about mineable?! 7/10
-											 && !staticVisible) //Xynth #135 7/2010
+                                             (static_cast<IasteroidIGC*>(pmodel)->GetCapabilities() & ~c_aabmBuildable) != 0))) //Imago - Review - what about mineable?! 7/10
 										{
                                             ObjectType  otSpotter = s->GetObjectType();
 											//Imago #121
@@ -11053,17 +11039,14 @@ class ThingSiteImpl : public ThingSite
                                 }
                             }
 
-                            if (!sv.fVisible())
-                            {
+                            if (!sv.fVisible() && seenBefore) {
                                 // hide it
+                                debugf("%s hide.\n", pmodel->GetName());
 								sv.CurrentEyed(false); //Xynth #100 7/2010
                                 HideObject(pside, pmodel);
                                 sv.pLastSpotter(NULL);
                             }
                         }                    
-					//} Xynth #100 need to make sure static objects are visible once spotted
-						if (staticVisible && !sv.CurrentEyed())
-							sv.fVisible(true);
                 }
             }
 		}

--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -10874,65 +10874,57 @@ class ThingSiteImpl : public ThingSite
 
 								// If the thing is in scanner range
 								if (s->InScannerRange(pmodel)) {
-									//Xynth something was just seen, I want to know if it was a probe that saw it and if this was high value target
-									if (s->GetObjectType() == OT_probe && pmodel->GetSide() != nullptr)
-									{
-										ObjectID spottedID = pmodel->GetObjectID();
-										IshipIGC* pSpottedShip = pmodel->GetSide()->GetShip(spottedID);	
 
-										// Guarding against server crash.
-										if (pSpottedShip != nullptr && pSpottedShip->GetHullType() != nullptr && pSpottedShip->GetHullType()->GetData() != nullptr)
-										{
-											AssetMask am = GetAssetMask(pSpottedShip, pSpottedShip->GetHullType(), false);
-											short hvMask = c_amEnemyMiner | c_amEnemyBuilder | c_amEnemyCapital | c_amEnemyCarrier | c_amEnemyBomber | c_amEnemyAPC | c_amEnemyTeleportShip;
-											if (am & hvMask)
-											{
-												ObjectID probeID = s->GetObjectID();
-												ImodelIGC * pProbeModel = s->GetMission()->GetModel(OT_probe, probeID);
-												IprobeIGC * pProbe = (IprobeIGC*)pProbeModel;
-												if (pProbe && !pSpottedShip->beenSpotted())
-												{
-													IshipIGC* pProbingShip = pProbe->GetProbeLauncherShip();
-													if (pProbingShip)
-													{
-														CFSShip* pfsShip = (CFSShip *)(pProbingShip->GetPrivateData());
-														if (pfsShip && pfsShip->IsPlayer())
-														{
-															CFSPlayer* pfsPlayer = pfsShip->GetPlayer();
-															if (pfsPlayer)
-															{
-																PlayerScoreObject * pso = pfsShip->GetPlayerScoreObject();
-																if (pso)
-																	pso->AddProbeSpot();
-																pfsPlayer->GetSteamAchievements()->AwardIGCAchievements(c_achmProbeSpot);
-															}
-														}
-													}
-												}
-											}
-										}
-										if (pSpottedShip) //mark ship as novelly spotted
-											pSpottedShip->SpotShip();
-									}
-									else if (OT_probe && pmodel->GetSide() != nullptr) //wasn't a probe but still want to mark it as a novel spot
-									{
-										ObjectID spottedID = pmodel->GetObjectID();
-										IshipIGC* pSpottedShip = pmodel->GetSide()->GetShip(spottedID);
-										if (pSpottedShip != nullptr)
-											pSpottedShip->SpotShip();
-									}
-
-									
 									bool bSent = false;
                                     //See it
 									if (!pmodel->SeenBySide(pside)) {
                                     	if (!staticVisible)  //Xynth #135 7/2010
-										{											
+										{
                                     		bSent = ShowObject(pside, pmodel);
 										}
 										sv.fVisible(true);
 										sv.CurrentEyed(true); //Xynth #100 7/2010
 
+                                        //Xynth: something was just seen, I want to know if it was a probe that saw it and if this was high value target; Radulfr: You also want to turn it into a ship, so ignore if it isn't one
+                                        if (pmodel->GetObjectType() == OT_ship)
+                                        {
+                                            IshipIGC* pSpottedShip = (IshipIGC*)pmodel;
+                                            if (pSpottedShip)
+                                            {
+                                                if (s->GetObjectType() == OT_probe && pSpottedShip->GetHullType() != nullptr && pSpottedShip->GetHullType()->GetData() != nullptr)
+                                                {
+                                                    AssetMask am = GetAssetMask(pSpottedShip, pSpottedShip->GetHullType(), false);
+                                                    short hvMask = c_amEnemyMiner | c_amEnemyBuilder | c_amEnemyCapital | c_amEnemyCarrier | c_amEnemyBomber | c_amEnemyAPC | c_amEnemyTeleportShip;
+                                                    if (am & hvMask)
+                                                    {
+                                                        ObjectID probeID = s->GetObjectID();
+                                                        ImodelIGC * pProbeModel = s->GetMission()->GetModel(OT_probe, probeID);
+                                                        IprobeIGC * pProbe = (IprobeIGC*)pProbeModel;
+                                                        if (pProbe && !pSpottedShip->PreviouslySpotted())
+                                                        {
+                                                            IshipIGC* pProbingShip = pProbe->GetProbeLauncherShip();
+                                                            if (pProbingShip)
+                                                            {
+                                                                CFSShip* pfsShip = (CFSShip *)(pProbingShip->GetPrivateData());
+                                                                if (pfsShip && pfsShip->IsPlayer())
+                                                                {
+                                                                    CFSPlayer* pfsPlayer = pfsShip->GetPlayer();
+                                                                    if (pfsPlayer)
+                                                                    {
+                                                                        PlayerScoreObject * pso = pfsShip->GetPlayerScoreObject();
+                                                                        if (pso)
+                                                                            pso->AddProbeSpot();
+                                                                        pfsPlayer->GetSteamAchievements()->AwardIGCAchievements(c_achmProbeSpot);
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                                //mark ship as previously spotted, no matter by whom
+                                                pSpottedShip->MarkPreviouslySpotted();
+                                            }
+                                        }
 									}
 									
 									if (pside->GetMission()->GetMissionParams()->bAllowAlliedViz) //ALLY should be SCAN Imago 7/11/09

--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -11041,7 +11041,6 @@ class ThingSiteImpl : public ThingSite
 
                             if (!sv.fVisible() && seenBefore) {
                                 // hide it
-                                debugf("%s hide.\n", pmodel->GetName());
 								sv.CurrentEyed(false); //Xynth #100 7/2010
                                 HideObject(pside, pmodel);
                                 sv.pLastSpotter(NULL);

--- a/src/Igc/common.cpp
+++ b/src/Igc/common.cpp
@@ -2645,21 +2645,21 @@ void   PlayerScoreObject::CalculateScore(ImissionIGC*   pmission)
     float   kMax = m_dtPlayed / (15.0f * 60.0f);    //1.0 / 15 minutes
 
 
-    m_fScore = float(m_cWarpsSpotted)       * pmission->GetFloatConstant(c_fcidPointsWarp) +
-        float(m_cAsteroidsSpotted)           * pmission->GetFloatConstant(c_fcidPointsAsteroid) +
+    m_fScore = float(m_cWarpsSpotted)       * pmission->GetFloatConstant(c_fcidPointsWarp) + // 2 on PCore15
+        float(m_cAsteroidsSpotted)           * pmission->GetFloatConstant(c_fcidPointsAsteroid) + // 1 on PCore15
         m_cTechsRecovered                    * pmission->GetFloatConstant(c_fcidPointsTech) +
         (m_cMinerKills * kMax)               * pmission->GetFloatConstant(c_fcidPointsMiner) / (m_cMinerKills + kMax) +
         (m_cBuilderKills * kMax)             * pmission->GetFloatConstant(c_fcidPointsBuilder) / (m_cBuilderKills + kMax) +
         (m_cLayerKills * kMax)               * pmission->GetFloatConstant(c_fcidPointsLayer) / (m_cLayerKills + kMax) +
         (m_cCarrierKills * kMax)             * pmission->GetFloatConstant(c_fcidPointsCarrier) / (m_cCarrierKills + kMax) +
-        m_cPlayerKills                       * pmission->GetFloatConstant(c_fcidPointsPlayer) +
+        m_cPlayerKills                       * pmission->GetFloatConstant(c_fcidPointsPlayer) + // 10 on PCore15
         (m_cBaseKills * kMax)                * pmission->GetFloatConstant(c_fcidPointsBaseKill) / (m_cBaseKills + kMax) +
         (m_cBaseCaptures * kMax)             * pmission->GetFloatConstant(c_fcidPointsBaseCapture) / (m_cBaseCaptures + kMax) +
         float(m_cRescues)                    * pmission->GetFloatConstant(c_fcidPointsRescues) +
         float(m_cArtifacts)                  * pmission->GetFloatConstant(c_fcidPointsArtifacts) +
         float(m_cFlags)                      * pmission->GetFloatConstant(c_fcidPointsFlags) +
-        float(m_cProbeSpot)                  * 10 +
-        float(m_cRepair)                     * 10;
+        m_cProbeSpot                         * 2 +
+        m_cRepair                            * 5;
 
     if (m_bWin)
         m_fScore *= 2.0f;

--- a/src/Igc/common.cpp
+++ b/src/Igc/common.cpp
@@ -2658,7 +2658,7 @@ void   PlayerScoreObject::CalculateScore(ImissionIGC*   pmission)
         float(m_cRescues)                    * pmission->GetFloatConstant(c_fcidPointsRescues) +
         float(m_cArtifacts)                  * pmission->GetFloatConstant(c_fcidPointsArtifacts) +
         float(m_cFlags)                      * pmission->GetFloatConstant(c_fcidPointsFlags) +
-        m_cProbeSpot                         * 2 +
+        float(m_cHighValueTargetsSpotted)    * 2 +
         m_cRepair                            * 5;
 
     if (m_bWin)

--- a/src/Igc/igc.h
+++ b/src/Igc/igc.h
@@ -3378,7 +3378,7 @@ class IshipIGC : public IscannerIGC
 		virtual void				ClearAchievementMask(void) = 0;
 		virtual AchievementMask		GetAchievementMask(void) const = 0;
 		virtual void				MarkPreviouslySpotted(void) = 0;
-		virtual bool				PreviouslySpotted(void) const = 0;
+		virtual bool				RecentlySpotted(void) const = 0;
         virtual DamageTrack*        GetDamageTrack(void) = 0;
         virtual void                CreateDamageTrack(void) = 0;
         virtual void                DeleteDamageTrack(void) = 0;
@@ -5516,7 +5516,7 @@ class PlayerScoreObject
             m_cPlayerKills = 0.0f;
             m_cBaseKills = 0.0f;
             m_cBaseCaptures = 0.0f;
-			m_cProbeSpot = 0;
+            m_cHighValueTargetsSpotted = 0;
 			m_cRepair = 0;
 
             m_cRescues = 0;
@@ -5629,10 +5629,14 @@ class PlayerScoreObject
             m_cAsteroidsSpotted++;
         }
 
-		void	AddProbeSpot(void)
+		void	AddTargetSpot(void)
 		{
-			m_cProbeSpot++;
+            m_cHighValueTargetsSpotted++;
 		}
+        short   GetTargetsSpotted(void)
+        {
+            return m_cHighValueTargetsSpotted;
+        }
 		void	SetRepair(float repair)
 		{
 			m_cRepair = repair;
@@ -5900,7 +5904,7 @@ class PlayerScoreObject
         float                       m_cPlayerKills;
         float                       m_cBaseKills;
         float                       m_cBaseCaptures;
-		short						m_cProbeSpot;
+		short						m_cHighValueTargetsSpotted;
 		float						m_cRepair;
 
         short                       m_cTechsRecovered;

--- a/src/Igc/igc.h
+++ b/src/Igc/igc.h
@@ -3377,8 +3377,8 @@ class IshipIGC : public IscannerIGC
 		virtual void				SetAchievementMask(AchievementMask am) = 0;
 		virtual void				ClearAchievementMask(void) = 0;
 		virtual AchievementMask		GetAchievementMask(void) const = 0;
-		virtual void				SpotShip(void) = 0;
-		virtual bool				beenSpotted(void) const = 0;
+		virtual void				MarkPreviouslySpotted(void) = 0;
+		virtual bool				PreviouslySpotted(void) const = 0;
         virtual DamageTrack*        GetDamageTrack(void) = 0;
         virtual void                CreateDamageTrack(void) = 0;
         virtual void                DeleteDamageTrack(void) = 0;
@@ -5631,7 +5631,7 @@ class PlayerScoreObject
 
 		void	AddProbeSpot(void)
 		{
-			m_cProbeSpot+=1;
+			m_cProbeSpot++;
 		}
 		void	SetRepair(float repair)
 		{

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -1250,7 +1250,7 @@ DamageResult CshipIGC::ReceiveDamage(DamageTypeID            type,
 			IshipIGC * pIship = ((IshipIGC*)launcher);
             float   repairFraction = -amount * dtmArmor / maxHP;
             if (GetBaseHullType() && (GetBaseHullType()->GetCapabilities() & c_habmThreatToStation))
-                repairFraction *= 2; //double points for nanning a bomber/htt
+                repairFraction *= 2.0f; //double points for nanning a bomber/htt
 			pIship->AddRepair(repairFraction);
 			pIship->SetAchievementMask(c_achmNewRepair);
 		}

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -1229,7 +1229,6 @@ DamageResult CshipIGC::ReceiveDamage(DamageTypeID            type,
 
     float   maxHP = m_myHullType.GetHitPoints();
     float   dtmArmor = GetMyMission()->GetDamageConstant(type, m_myHullType.GetDefenseType());
-	float   repairFraction;
     assert (dtmArmor >= 0.0f);
 
     float leakage;
@@ -1243,17 +1242,15 @@ DamageResult CshipIGC::ReceiveDamage(DamageTypeID            type,
 			m_fraction = 1.0f;
 		}            
         GetThingSite ()->RemoveDamage (m_fraction);
-		if (GetMyMission()->GetMissionParams()->bAllowFriendlyFire || //no points when FF is on
-			!((pside == launcher->GetSide()) || IsideIGC::AlliedSides(pside, launcher->GetSide()))) //no points for healing the enemy
-			repairFraction = 0;
-		else
-			repairFraction = fabs(amount * dtmArmor / maxHP);
         leakage = 0.0f;
         dr = c_drNoDamage;
-		if (launcher->GetObjectType() == OT_ship && (pside == launcher->GetSide()) || IsideIGC::AlliedSides(pside, launcher->GetSide()))
-		{
 
+		if (launcher->GetObjectType() == OT_ship && (pside == launcher->GetSide() || IsideIGC::AlliedSides(pside, launcher->GetSide())))
+		{
 			IshipIGC * pIship = ((IshipIGC*)launcher);
+            float   repairFraction = -amount * dtmArmor / maxHP;
+            if (GetBaseHullType() && (GetBaseHullType()->GetCapabilities() & c_habmThreatToStation))
+                repairFraction *= 2; //double points for nanning a bomber/htt
 			pIship->AddRepair(repairFraction);
 			pIship->SetAchievementMask(c_achmNewRepair);
 		}

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -196,7 +196,7 @@ HRESULT     CshipIGC::Initialize(ImissionIGC* pMission, Time now, const void* da
     m_wingmanBehaviour = c_wbbmUseMissiles | c_wbbmRunAt60Hull;
 	m_repair = 0; //Xynth amount of nanning performed by ship
 	m_achievementMask = 0;
-	m_hasBeenSpotted = false; //Xynth if this ship has been spotted
+	m_previouslySpotted = false; //Xynth if this ship has been spotted
     
 	return S_OK;
 }

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -196,7 +196,7 @@ HRESULT     CshipIGC::Initialize(ImissionIGC* pMission, Time now, const void* da
     m_wingmanBehaviour = c_wbbmUseMissiles | c_wbbmRunAt60Hull;
 	m_repair = 0; //Xynth amount of nanning performed by ship
 	m_achievementMask = 0;
-	m_previouslySpotted = false; //Xynth if this ship has been spotted
+	m_timePreviouslySpotted = 0;
     
 	return S_OK;
 }
@@ -2500,7 +2500,7 @@ void    CshipIGC::PlotShipMove(Time          timeStop)
 
                                 }
                                 else {
-                                    if ((m_wingmanBehaviour & c_wbbmInRangeAggressive) && (m_timeRanAway + 10.0 <= timeStop)) { //m_timeRanAway gets set on SetCommand c_cmdPlan
+                                    if ((m_wingmanBehaviour & c_wbbmInRangeAggressive) && (m_timeRanAway + 10.0f <= timeStop)) { //m_timeRanAway gets set on SetCommand c_cmdPlan
                                         ImodelIGC* newTarget = NULL;
                                         for (ShipLinkIGC* l = GetCluster()->GetShips()->first(); (l != NULL); l = l->next()) {
                                             if (ModelHasTargetPriority(l->data(), this)) {
@@ -2718,7 +2718,7 @@ void    CshipIGC::PlotShipMove(Time          timeStop)
                             // assume we just got a goto plan to find our actual target. Attack it.
                             SetCommand(c_cmdPlan, m_commandTargets[c_cmdAccepted], c_cidAttack);
                         }
-                        if ((m_wingmanBehaviour & (c_wbbmInRangeAggressive | c_wbbmTempSectorAggressive)) && (m_timeRanAway + 10.0 <= timeStop)) {
+                        if ((m_wingmanBehaviour & (c_wbbmInRangeAggressive | c_wbbmTempSectorAggressive)) && (m_timeRanAway + 10.0f <= timeStop)) {
                             ImodelIGC* newTarget = NULL;
                             for (ShipLinkIGC* l = GetCluster()->GetShips()->first(); (l != NULL); l = l->next()) {
                                 if (ModelHasTargetPriority(l->data(), this)) {

--- a/src/Igc/shipIGC.h
+++ b/src/Igc/shipIGC.h
@@ -1877,12 +1877,12 @@ class       CshipIGC : public TmodelIGC<IshipIGC>
 
 		virtual void MarkPreviouslySpotted(void)
 		{
-            m_previouslySpotted = true;
+            m_timePreviouslySpotted = GetMyLastUpdate();
 		}
 
-		virtual bool PreviouslySpotted(void) const
+		virtual bool RecentlySpotted(void) const
 		{
-			return m_previouslySpotted;
+            return (GetMyLastUpdate() - m_timePreviouslySpotted < 50.0f);
 		}
 		virtual float GetRepair(void) const
 		{
@@ -2507,7 +2507,7 @@ class       CshipIGC : public TmodelIGC<IshipIGC>
         
 		float				m_repair; //Xynth amount of nanning performed by ship
 		AchievementMask		m_achievementMask;
-		bool				m_previouslySpotted;
+		Time				m_timePreviouslySpotted;
 
 };
 

--- a/src/Igc/shipIGC.h
+++ b/src/Igc/shipIGC.h
@@ -1875,14 +1875,14 @@ class       CshipIGC : public TmodelIGC<IshipIGC>
 			m_repair += repair; //Xynth amount of nanning performed by ship as a fraction of hull repaired
 		}
 
-		virtual void SpotShip(void)
+		virtual void MarkPreviouslySpotted(void)
 		{
-			m_hasBeenSpotted = true;
+            m_previouslySpotted = true;
 		}
 
-		virtual bool beenSpotted(void) const
+		virtual bool PreviouslySpotted(void) const
 		{
-			return m_hasBeenSpotted;
+			return m_previouslySpotted;
 		}
 		virtual float GetRepair(void) const
 		{
@@ -2507,7 +2507,7 @@ class       CshipIGC : public TmodelIGC<IshipIGC>
         
 		float				m_repair; //Xynth amount of nanning performed by ship
 		AchievementMask		m_achievementMask;
-		bool				m_hasBeenSpotted;
+		bool				m_previouslySpotted;
 
 };
 

--- a/src/Igc/stationIGC.cpp
+++ b/src/Igc/stationIGC.cpp
@@ -293,7 +293,8 @@ const ShipListIGC*        CstationIGC::GetShips(void) const
 void CstationIGC::Launch(IshipIGC* pship)
 {
 	Orientation orientation;
-    Vector position(random(-0.5f, 0.5f), random(-0.5f, 0.5f), random(-0.5f, 0.5f));
+    const float maxRandomOffset = 5.0f;
+    Vector position(random(-maxRandomOffset, maxRandomOffset), random(-maxRandomOffset, maxRandomOffset), random(-maxRandomOffset, maxRandomOffset));
     Vector forward;
 
     const Orientation&  o = GetOrientation();
@@ -336,7 +337,7 @@ void CstationIGC::Launch(IshipIGC* pship)
             }
         }
 
-        position += forward * (GetRadius() + pship->GetRadius() + vLaunch * 0.5f);
+        position += forward * (GetRadius() + pship->GetRadius() + vLaunch * 0.5f + maxRandomOffset);
     }
     else
     { 
@@ -349,10 +350,10 @@ void CstationIGC::Launch(IshipIGC* pship)
 		float	m_fDeltaTime = (float)(lastUpdate - lastLaunch);
 		//debugf(" *** %s(%i) launch time cluster delta = %f\n\n", m_myStationType.GetName(), m_myStationType.GetObjectID(), m_fDeltaTime);
 		if (m_fDeltaTime <= 0.1f) {
-			 position += forward * (pship->GetRadius() + vLaunch * 0.85f);
+			 position += forward * (pship->GetRadius() + vLaunch * 0.85f + maxRandomOffset);
 			 //debugf("*** %s(%i) position adjusted to ensure smooth take-off\n",pship->GetName(),pship->GetObjectID());
 		} else {
-			 position += forward * (pship->GetRadius() + vLaunch * 0.5f);
+			 position += forward * (pship->GetRadius() + vLaunch * 0.5f + maxRandomOffset);
 		}
 		//
 


### PR DESCRIPTION
Random:
Increasing random offset for teleporting and launching from base. This makes for less jerky collisions when multiple ships teleport at the same time and as such might fix a disconnect/crash on too many collisions.

Xynth:
- Renaming, moving, cleaning up Xynth's high-value-spot achievement/score.
 => Running a lot less checks per frame
 => More readable code
- Fixing potential nan score crash
- Differentiating between naning a bomber/htt or normal ship
- Adjusting score points to fit with core values
- Awarding score for spotting high-value targets with a ship too
- Give points for spotting a target again after 50 seconds
- Overhaul UpdateSideVisibility() to make it work as intended
 => A LOT more efficient
 => slightly more readable