### PR TITLE
Miner AI improvements

### DIFF
--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -3187,22 +3187,21 @@ bool CommandToDrone(CFSMission*         pfsMission,
     if ((pcd->commandID != c_cidNone) &&
         (pfsSender->GetIGCShip()->GetSide() == pside))
     {
+        pshipTo->SetRunawayCheckCooldown(120.0f); // don't run anytime soon while executing a player command
+
         IclusterIGC* pminerCluster = NULL;
         char pcReply[100] = "Affirmative.";
         if (*ppmodelTarget == NULL)
 		{
             if (pdb)
             {
-                if (pshipTo->GetPilotType() == c_ptMiner && pdb->type == c_buoyCluster) {
+                if (pshipTo->GetPilotType() == c_ptMiner && pdb->type == c_buoyCluster)
                     pminerCluster = pfsMission->GetIGCMission()->GetCluster(pdb->clusterID);
-                }
-                else {
-                    //Create a buoy for this chat message
-                    *ppmodelTarget = (ImodelIGC*)(pfsMission->GetIGCMission()->CreateObject(g.timeNow, OT_buoy, pdb, sizeof(*pdb)));
-                    assert (*ppmodelTarget);
+                //Create a buoy for this chat message
+                *ppmodelTarget = (ImodelIGC*)(pfsMission->GetIGCMission()->CreateObject(g.timeNow, OT_buoy, pdb, sizeof(*pdb)));
+                assert(*ppmodelTarget);
 
-                    ((IbuoyIGC*)*ppmodelTarget)->AddConsumer();
-                }
+                ((IbuoyIGC*)*ppmodelTarget)->AddConsumer();
             }
             else
             {
@@ -3241,74 +3240,6 @@ bool CommandToDrone(CFSMission*         pfsMission,
                 }
             }
 
-            if (pminerCluster) {
-                IstationIGC* pstationToDock = NULL;
-                for (StationLinkIGC* l = pminerCluster->GetStations()->first(); (l != NULL); l = l->next()) {
-                    IstationIGC* pcurStation = l->data();
-                    if (pcurStation->GetSide() == pside) {
-                        pstationToDock = pcurStation;
-                        break;
-                    }
-                }
-                bool mine = false;
-
-                CompactShipFractions fractions;
-                pshipTo->ExportFractions(&fractions);
-                float capacity = pside->GetMission()->GetFloatConstant(c_fcidCapacityHe3) *
-                    pside->GetGlobalAttributeSet().GetAttribute(c_gaMiningCapacity);
-                // Should we try to mine?
-                if ((fractions.GetShieldFraction()>0.5 || !pstationToDock) &&
-                    (pshipTo->GetOre() < capacity / 2.0f || (!pstationToDock && pshipTo->GetOre() < capacity))) 
-                {
-                    ImodelIGC*  pmodel = FindTarget(pshipTo,
-                        c_ttNeutral | c_ttAsteroid | c_ttNearest |
-                        c_ttLeastTargeted | c_ttCowardly,
-                        NULL, pminerCluster, &(pshipTo->GetPosition()), NULL,
-                        pshipTo->GetOrdersABM());
-
-                    if (pmodel) {
-                        sprintf(pcReply, "Affirmative, going to mine in %s.", pminerCluster->GetName());
-                        *ppmodelTarget = pmodel;
-                        pcd->commandID = c_cidMine;
-                        mine = true;
-                    }
-                }
-
-                if (!mine) {
-                    if (pstationToDock) {
-                        sprintf(pcReply, "Affirmative, going to dock in %s.", pminerCluster->GetName());
-                        *ppmodelTarget = pstationToDock;
-                        pcd->commandID = c_cidGoto;
-                    }
-                    else {
-                        // check if the side has explored the sector
-                        bool knownSector = false;
-                        for (AsteroidLinkIGC* l = pminerCluster->GetAsteroids()->first(); (l != NULL); l = l->next()) {
-                            IasteroidIGC* pcurRoid = l->data();
-                            if (pcurRoid->SeenBySide(pside)) {
-                                knownSector = true;
-                                break;
-                            }
-                        }
-
-                        DataBuoyIGC         buoyData;
-                        buoyData.position = Vector(0.0f, 0.0f, 0.0f);
-                        if (!knownSector && pshipTo->GetOre() < capacity / 2.0f) {
-                            //debugf(" send the miner just inside the sector, will find an asteroid there.\n");
-                            buoyData.type = c_buoyCluster;
-                        }
-                        else {
-                            //debugf(" send the miner to the center of the sector.\n");
-                            buoyData.type = c_buoyWaypoint;
-                        }
-                        buoyData.clusterID = pminerCluster->GetObjectID();
-                        buoyData.buoyID = pfsMission->GetIGCMission()->GenerateNewBuoyID();
-
-                        *ppmodelTarget = (ImodelIGC*)(pfsMission->GetIGCMission()->CreateObject(g.timeNow, OT_buoy, &buoyData, sizeof(buoyData)));
-                        pcd->commandID = c_cidGoto;
-                    }
-                }
-            }
         }
         if ((pcd->commandID == c_cidDefault) && (*ppmodelTarget != NULL))
         {
@@ -3357,20 +3288,32 @@ bool CommandToDrone(CFSMission*         pfsMission,
                                             */
         }
 
+        // Remember player commands by storing location/ID in c_cmdQueued
         if (pshipTo->GetPilotType() == c_ptMiner) {
             if ((*ppmodelTarget) &&
                 (*ppmodelTarget)->GetObjectType() != OT_station &&
                 (*ppmodelTarget)->GetObjectType() != OT_ship)
             {
-                pshipTo->SetCommand(c_cmdQueued, (ImodelIGC*)(*ppmodelTarget)->GetCluster(), c_cidDefault);
-            }
-            else
-                pshipTo->SetCommand(c_cmdQueued, NULL, c_cidNone);
+                DataBuoyIGC         buoyData;
+                buoyData.position = Vector(0.0f, 0.0f, 0.0f);
+                buoyData.type = c_buoyWaypoint; // c_buoyCluster would be deleted as soon as we are in the cluster
+                if (pminerCluster)
+                    buoyData.clusterID = pminerCluster->GetObjectID();
+                else
+                    buoyData.clusterID = (*ppmodelTarget)->GetCluster()->GetObjectID();
+                buoyData.buoyID = pfsMission->GetIGCMission()->GenerateNewBuoyID();
+                ImodelIGC* buoy = (ImodelIGC*)(pfsMission->GetIGCMission()->CreateObject(g.timeNow, OT_buoy, &buoyData, sizeof(buoyData)));
 
-            if (pminerCluster) {
-                if ((*ppmodelTarget)->GetObjectType() == OT_buoy)
-                    (*ppmodelTarget)->Release();
-                *ppmodelTarget = NULL; //no more clean-up needed
+                CommandID cid = c_cidGoto;
+                if (pminerCluster)
+                    cid = c_cidJoin;
+                pshipTo->SetCommand(c_cmdQueued, buoy, cid);
+
+                buoy->Release(); //SetCommand added the consumer needed
+            }
+            else {
+                // Remember that we just got a player command -> c_cidGoto instead of None
+                pshipTo->SetCommand(c_cmdQueued, NULL, c_cidGoto);
             }
         }
     }
@@ -7337,6 +7280,7 @@ HRESULT FedSrvSiteBase::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxnF
 								NULL, NULL, NULL, NULL, c_sabmRepair);
 				}
 				pship->SetStayDocked(true);
+                pship->SetCommand(c_cmdQueued, NULL, c_cidNone); //Don't remember any sector
 				if (pmodel)
 				{
 					pfsMission->GetSite()->SendChat(pship, CHAT_INDIVIDUAL, pfsPlayer->GetIGCShip()->GetObjectID(),
@@ -10963,6 +10907,7 @@ class ThingSiteImpl : public ThingSite
 											//Imago #121
 											if (otModel == OT_station) {
                                                 pside->UpdateTerritory();
+                                                pside->HandleNewEnemyCluster(pmodel->GetCluster());
 
 												ObjectID roidID = static_cast<IstationIGC*>(pmodel)->GetRoidID();
 												//asteroid to silently pop
@@ -13416,6 +13361,9 @@ bool FedSrvSiteBase::UseRipcord(IshipIGC* pship, ImodelIGC* pmodel)
         }
 		*/
     }
+
+    CFSShip* pfsShip = (CFSShip*)pship->GetPrivateData();
+    pfsShip->ShipStatusSpotted(pship->GetSide());
 
     return true;
 }

--- a/src/FedSrv/fsship.cpp
+++ b/src/FedSrv/fsship.cpp
@@ -684,8 +684,12 @@ void CFSShip::CaptureStation(IstationIGC * pstation)
 
   for (SideLinkIGC* l = pside->GetMission()->GetSides()->first(); (l != NULL); l = l->next()) {
       IsideIGC* pcurSide = l->data();
-      if (pcurSide == pside || pcurSide == psideOld || IsideIGC::AlliedSides(pside, pcurSide) || IsideIGC::AlliedSides(psideOld, pcurSide)) {
-          l->data()->UpdateTerritory();
+      if (pcurSide == psideOld || IsideIGC::AlliedSides(psideOld, pcurSide)) {
+          pcurSide->HandleNewEnemyCluster(pstation->GetCluster());
+          pcurSide->UpdateTerritory();
+      }
+      else if (pcurSide == pside || IsideIGC::AlliedSides(pside, pcurSide)) {
+          pcurSide->UpdateTerritory();
       }
   }
 }

--- a/src/Igc/igc.h
+++ b/src/Igc/igc.h
@@ -3358,6 +3358,8 @@ class IshipIGC : public IscannerIGC
         virtual bool                LegalCommand(CommandID   cid,
                                                  ImodelIGC*  pmodel) const = 0;
 
+        virtual void                SetRunawayCheckCooldown(float dtRunAway) = 0;
+
         virtual IshipIGC*           GetAutoDonate(void) const = 0;
         virtual void                SetAutoDonate(IshipIGC* pship) = 0;
 
@@ -4287,6 +4289,7 @@ class IsideIGC : public IbaseIGC
 		//Xynth Adding function to return number of players on a side
 		virtual int GetNumPlayersOnSide(void) const = 0;
 
+        virtual void HandleNewEnemyCluster(IclusterIGC* pcluster) = 0;
         //Territory clusters
         virtual void UpdateTerritory() = 0;
         virtual ClusterListIGC GetTerritory() = 0;

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -183,6 +183,7 @@ HRESULT     CshipIGC::Initialize(ImissionIGC* pMission, Time now, const void* da
     ReInitialize(dataShip, now);
     pMission->AddShip(this);
 
+    m_dtCheckRunaway = 31.0f;
     m_timeLastComplaint = now;
     m_timeLastMineExplosion = now;
     m_timeRanAway = now;
@@ -1710,9 +1711,9 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
             }
 
         // Do we need to run away?
-        if (m_pilotType < c_ptPlayer && m_pilotType != c_ptCarrier && !fRipcordActive())      //Carriers never run //TurkeyXIII added ripcord 7/10 - Imago
+        if (m_pilotType < c_ptPlayer && m_pilotType != c_ptCarrier && (!fRipcordActive() || m_bRunningAway))      //Carriers never run //TurkeyXIII added ripcord 7/10 - Imago
         {
-            if (m_timeRanAway + c_dtCheckRunaway <= timeStop)
+            if (m_timeRanAway + m_dtCheckRunaway <= timeStop)
             {
                 bool    bDamage = true;
                 bool    bRunAway = true;
@@ -1782,14 +1783,14 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
 					              m_pilotType);
 						}
 					}
-                    if (m_fraction >= 0.95f)  // mmf added Your_Persona's change, allow Miners to be slightly damaged  (was == 100.0f)
+                    if (m_fraction >= 0.95f || (!m_bRunningAway && m_fraction >= m_fractionLastOrder && m_fraction > 0.5f)) // barely damaged or not more damaged than previously
                     {
                         IshieldIGC* pshield = (IshieldIGC*)(m_mountedOthers[ET_Shield]);
                         if ((pshield == NULL) || (pshield->GetFraction() >= 0.75f))
                         {
                             bDamage = false;
 
-                            //full hull & shield
+                            // 95% hull & 75% shield
                             //Does anyone see us?
                             IsideIGC*       psideMe = GetSide();
 
@@ -1797,6 +1798,7 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
                             int     cFriend = 0;
                             float   d2Enemy = FLT_MAX;
                             float   d2Friend = FLT_MAX;
+                            bool    enemyBasicScout = false;
 
                             for (ShipLinkIGC*   psl = pcluster->GetShips()->first(); (psl != NULL); psl = psl->next())
                             {
@@ -1807,9 +1809,8 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
                                 {
                                     IsideIGC*   pside = pship->GetSide();
 
-                                    if (((pside == psideMe) || pside->AlliedSides(pside,psideMe)) ||
-										(CanSee(pship) && SeenBySide(pside)) //#ALLY - friendly nearby (seen or can see us) IMAGO FIXED 7/10/09
-										)
+                                    if ((pside == psideMe) || 
+                                        (pside->AlliedSides(pside,psideMe) && CanSee(pship) && SeenBySide(pside)))
                                     {
                                         cFriend++;
                                         float d2 = (positionMe - pship->GetPosition()).LengthSquared();
@@ -1818,15 +1819,31 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
                                     }
                                     else if (CanSee(pship) && SeenBySide(pside))
                                     {
-                                        cEnemy++;
                                         float d2 = (positionMe - pship->GetPosition()).LengthSquared();
-                                        if (d2 < d2Enemy)
-                                            d2Enemy = d2;
+                                        bool threat = (d2 < 4000000.0f); //closer than 2000m
+                                        if (!threat && pship->GetVelocity().Length() > pship->GetHullType()->GetMaxSpeed()*0.65) {
+                                            Orientation oToMiner = Orientation(GetPosition() - pship->GetPosition());
+                                            float shipDirSpeed = oToMiner.CosForward(pship->GetVelocity())*pship->GetVelocity().Length();
+                                            if (shipDirSpeed > 0.7*pship->GetVelocity().Length()) // flying 70% to the miner
+                                                threat = true;
+                                        }
+                                        if (threat) {
+                                            cEnemy++;
+                                            if (d2 < d2Enemy)
+                                                d2Enemy = d2;
+
+                                            // Check if it's a basic scout
+                                            const IhullTypeIGC* pht = pship->GetHullType();
+                                            enemyBasicScout = (pht->GetDefenseType() == 1 && // light armor
+                                                pht->GetScannerRange() > 2200.0f && pht->GetScannerRange() < 2950.0f);
+                                        }
                                     }
                                 }
                             }
 
-                            if (cFriend >= cEnemy)
+                            //debugf("%s, friends: %d, foes: %d\n", (enemyBasicScout ? "basicScout" : "-"), cFriend, cEnemy);
+
+                            if ((cFriend >= cEnemy) || (enemyBasicScout && cEnemy == cFriend + 1))
                                 bRunAway = false;
                             else
                             {
@@ -1876,6 +1893,9 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
                             m_bRunningAway = true;
                             m_timeRanAway = timeStop;
 
+                            // Check if we should still run away in 10 seconds
+                            m_dtCheckRunaway = 10.0f;
+
 						    //mmf debuging code
 						    //debugf("mmf Miner/con found place to run to.\n");
 							//debugf("%-20s %x I am at %f %f %f\n", GetName(), timeStop.clock(), positionMe.x, positionMe.y, positionMe.z);
@@ -1887,7 +1907,12 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
                 else if (m_bRunningAway)
                 {
                     //We want to stop running
-                    SetCommand(c_cmdPlan, NULL, c_cidNone);
+                    if (m_pilotType == c_ptMiner && m_commandTargets[c_cmdAccepted] && m_commandTargets[c_cmdAccepted]->GetCluster() != GetCluster()) {
+                        // If we ran too far (especially IC miner after ripping), check for the best thing to do, instead of continuing the previous
+                        SetCommand(c_cmdAccepted, NULL, c_cidNone); //Also sets c_cmdPlan
+                    }
+                    else
+                        SetCommand(c_cmdPlan, NULL, c_cidNone);
 					// debugf("mmf %-20s stoped running\n", GetName());
                     assert (m_bRunningAway == false);   //Set by SetCommand
                     m_timeRanAway = timeStop;

--- a/src/Igc/sideigc.h
+++ b/src/Igc/sideigc.h
@@ -591,6 +591,7 @@ class       CsideIGC : public IsideIGC
 		{
 			return m_data.allies;
 		}
+        void HandleNewEnemyCluster(IclusterIGC* pcluster);
 
         void UpdateTerritory();
 

--- a/src/WinTrek/WinTrek.cpp
+++ b/src/WinTrek/WinTrek.cpp
@@ -11157,11 +11157,6 @@ public:
         //bool newButton5 = m_ptrekInput->GetButton(4); // !!! was vector lock
         bool newButton6 = m_ptrekInput->IsTrekKeyDown(TK_MatchSpeed , bReadKeyboard);
 
-        if (newButton3) {
-            trekClient.trekThrottle = 1.0f;
-            bThrottleChange = !trekClient.joyThrottle;
-        }
-
         if (bInternalCamera)
         {
             // roll left/right

--- a/src/clintlib/clintlib.h
+++ b/src/clintlib/clintlib.h
@@ -2200,7 +2200,7 @@ public:
 
         // Check if it's a combat ship or a scout-like one
         bool combatShip = !(pht->GetDefenseType() == 1 && // light armor
-            pht->GetScannerRange() >= 2200);
+            pht->GetScannerRange() >= 2200.0f);
 
         //Start actually filling the cargo
         Mount   cargo = -c_maxCargo;


### PR DESCRIPTION
**Miner AI**
- Undid the previous change of miners selecting a target before being in the sector they are sent to.
- Instead: On arriving in a new sector, they take into account if it was a player command and make sure not to go back to the previous sector.
- The territory system, used for considering sectors surrounded by friendly sectors as safe, is used for navigating as well
- On discovering a new enemy sector/station, miners will stop going there/suiciding
- Miners now run again due to nearby enemies considered a threat.
- Miners consider running later after a player command; Sooner after coming up with their own action.
- Miners will not chicken out due to low hull with (almost) full shield
- Miners/cons cancel running (even when ripping) if the threat is gone

**Unrelated**
- Undid the 100% throttle on boost
- visibility fix for friendly ripping