### PR TITLE
Revert "Disable running due to nearby threats"

### DIFF
--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -1790,10 +1790,8 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
                         {
                             bDamage = false;
 
-                            bRunAway = false; //Never run away if not damaged sufficiently
-
                             // 95% hull & 75% shield
-                            /*//Does anyone see us? Run due to enemy threat.
+                            //Does anyone see us?
                             IsideIGC*       psideMe = GetSide();
 
                             int     cEnemy = 0;
@@ -1852,7 +1850,7 @@ void    CshipIGC::PreplotShipMove(Time          timeStop)
                                 static const float  c_d2AlwaysRun = 1000.0f;
                                 if (d2Enemy > c_d2AlwaysRun * c_d2AlwaysRun)
                                     bRunAway = (d2Enemy < d2Friend);
-                            }*/
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This reverts commit dc82dca2207141b9dc06877a1c156c4e2a557130.

Seems like a silly commit to keep the miner from running.  Just a first glance at it.  Hoping this pull request will start some discussion around fixing miner AI.

I can't build the code myself (not on Windows) so please comment and check it out.