### PR TITLE
Update README to include build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Installation
 
-Download and install the lastest "Visual Studio Community Edition" : https://www.visualstudio.com/downloads/
+Download and install the latest "Visual Studio Community Edition" : https://www.visualstudio.com/downloads/
 
 Download and install the latest Microsoft DirectX SDK (jun 2010): https://www.microsoft.com/en-us/download/details.aspx?id=6812 (if you don't want to install it, just extract the DirectX `include` and `lib` folders somewhere and set the environment variable `DXSDK_DIR` to their parent directory)
 
@@ -21,6 +21,9 @@ This can be accessed from the installer, or from the Tab `Tools` -> `Get Tools A
 ### Individual Components
 #### SDK's, libraries, and frameworks
 * C++ MFC for latest v143 build tools (x86 & x64)
+
+# Build
+Once the solution, there is a button at the top to build. The configuration might need to change from `Debug` to `FZDebug`, `FZRelease`, or `Release`, if `Debug` does not build correctly.
 
 # Main projects
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Download and install the latest Microsoft DirectX SDK (jun 2010): https://www.mi
 
 Launch Visual Studio and open the main solution `src\VS2022\Allegiance.sln`
 
+There should be a prompt in the solution view to install required tools. If this is not the case, the installation will need to be modified.
+This can be accessed from the installer, or from the Tab `Tools` -> `Get Tools And Features`.
+
+## Required Tools
+### Workloads
+#### Desktop & Mobile
+* .NET desktop development
+* Desktop development with C++
+
+### Individual Components
+#### SDK's, libraries, and frameworks
+* C++ MFC for latest v143 build tools (x86 & x64)
+
 # Main projects
 
 * Allegiance (`WinTrek` folder) : the main client program


### PR DESCRIPTION
Add needed build tools to README, in the event that VSCode does not prompt for installation