### PR TITLE
Fix bases with no shields, add kb to asteroid, missiles, add kb to repairs

### DIFF
--- a/src/FedSrv/fsship.cpp
+++ b/src/FedSrv/fsship.cpp
@@ -580,9 +580,20 @@ void CFSShip::CaptureStation(IstationIGC * pstation)
     //Fudge the hitpoints of the station
     //All those guns inside damage the hull
     pstation->SetFraction(pstation->GetFraction() * 0.5f);
-
+    
+    //Student 8/3/2022, make the heroic engineer boost the shield regen
+    //This means that bases with 0 shield regen don't get shields
+    //Also slightly nerf shield regain from 80% to 70% to allow more variance in shield regen
+     
     //But the heroic engineer's get the shields up.
-    pstation->SetShieldFraction(0.8f); //pstation->GetShieldFraction() + 0.5f);
+    float heroicEngineerShieldBoost = 0.0f; //default, station has no shield regen to get up
+    if (pstation->GetStationType()->GetMaxShieldHitPoints() != 0) //prevent divide by zero
+    {
+        float regenRatio = pstation->GetStationType()->GetShieldRegeneration() / pstation->GetStationType()->GetMaxShieldHitPoints(); //Generally, this will be 0.10f as of ac_07
+        heroicEngineerShieldBoost = regenRatio * 7.0f; //multiply by 7 to get to 0.7f
+    }
+    
+    pstation->SetShieldFraction(heroicEngineerShieldBoost); //pstation->SetShieldFraction(0.8f) //pstation->GetShieldFraction() + 0.5f); 
   }
 
   {

--- a/src/Igc/asteroidigc.h
+++ b/src/Igc/asteroidigc.h
@@ -134,6 +134,10 @@ class   CasteroidIGC : public TmodelIGC<IasteroidIGC>
 
             amount *= GetMyMission()->GetDamageConstant(type, c_defidAsteroid);
 
+            //Student 8/3/2022 applying experience modifier (kb) earlier asteroids
+            if (launcher && (launcher->GetObjectType() == OT_ship))
+                amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier();
+
             if (amount < 0.0f)
             {
                 m_fraction -= amount / float(m_asteroidDef.hitpoints);

--- a/src/Igc/missileigc.h
+++ b/src/Igc/missileigc.h
@@ -98,6 +98,12 @@ class CmissileIGC : public TmodelIGC<ImissileIGC>
             amount *= GetMyMission()->GetDamageConstant(type, m_missileType->GetDefenseType());
 
             float   maxHP = m_missileType->GetHitPoints();
+            
+            //Student 8/3/2022 applying experience modifier (kb) to apply to missiles
+            if (launcher && (launcher->GetObjectType() == OT_ship))
+            {
+                amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier();
+            }
 
             if (amount < 0.0f)
             {
@@ -139,7 +145,7 @@ class CmissileIGC : public TmodelIGC<ImissileIGC>
             return m_fraction * m_missileType->GetHitPoints();
         }
 
-    // ImissileIGC
+    // ImissileIGC //Student NOTE, give possibility of reaquiring target?
         virtual ImissileTypeIGC*    GetMissileType(void) const
         {
             return m_missileType;

--- a/src/Igc/probeigc.h
+++ b/src/Igc/probeigc.h
@@ -94,6 +94,10 @@ class CprobeIGC : public TmodelIGC<IprobeIGC>
             float   maxHP = m_probeType->GetHitPoints();
             amount *= GetMyMission()->GetDamageConstant(type, m_probeType->GetDefenseType());
 
+            //Student 8/3/2022 applying experience modifier (kb) earlier to apply to repairs
+            if (launcher && (launcher->GetObjectType() == OT_ship))
+                    amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier();
+
             if (amount < 0.0f)
             {
                 if (maxHP > 0.0f)
@@ -106,8 +110,8 @@ class CprobeIGC : public TmodelIGC<IprobeIGC>
             }
             else if (amount > 0.0f)
             {
-                if (launcher && (launcher->GetObjectType() == OT_ship))
-                    amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier();
+                //if (launcher && (launcher->GetObjectType() == OT_ship))
+                //    amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier(); //Student 8/3/2022 applying experience modifier (kb) earlier to apply to repairs
 
                 m_fraction = maxHP > 0.0f ? (m_fraction - amount / maxHP) : 0.0f;
                 if (m_fraction <= 0.0f)

--- a/src/Igc/shipIGC.cpp
+++ b/src/Igc/shipIGC.cpp
@@ -1234,6 +1234,13 @@ DamageResult CshipIGC::ReceiveDamage(DamageTypeID            type,
     assert (dtmArmor >= 0.0f);
 
     float leakage;
+
+    //Student 8/3/2022 applying experience modifier (kb) earlier to apply to repairs
+    if (launcher && launcher->GetObjectType() == OT_ship)
+    {
+        amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier();
+    }
+            
     if (amount < 0.0f)
     {
         //Repair the target's hull
@@ -1264,8 +1271,8 @@ DamageResult CshipIGC::ReceiveDamage(DamageTypeID            type,
 
         if (launcher)
         {
-            if (launcher->GetObjectType() == OT_ship)
-                amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier(); //Student Note: This is kb multiplier. Also, repairing is not affected by kb
+            //if (launcher->GetObjectType() == OT_ship)
+            //    amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier(); //Student 8/3/2022 applying experience modifier (kb) earlier to apply to repairs
 
             if (m_damageTrack && (launcher->GetMission() == GetMyMission()))
                 m_damageTrack->ApplyDamage(timeCollision, launcher, amount);

--- a/src/Igc/stationIGC.cpp
+++ b/src/Igc/stationIGC.cpp
@@ -138,6 +138,12 @@ DamageResult    CstationIGC::ReceiveDamage(DamageTypeID            type,
     float   dtmArmor = GetMyMission()->GetDamageConstant(type, m_myStationType.GetArmorDefenseType());
     assert (dtmArmor >= 0.0f);
 
+    //Student 8/3/2022 applying experience modifier (kb) earlier to apply to repairs
+    if (launcher && launcher->GetObjectType() == OT_ship)
+    {
+        amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier();
+    }
+
     if (amount < 0.0f)
     {
         m_hullFraction -= amount * dtmArmor / maxArmor;
@@ -156,8 +162,8 @@ DamageResult    CstationIGC::ReceiveDamage(DamageTypeID            type,
         {
             dr = c_drShieldDamage;
 
-            if (launcher && (launcher->GetObjectType() == OT_ship))
-                amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier();
+            //if (launcher && (launcher->GetObjectType() == OT_ship))
+            //    amount *= ((IshipIGC*)launcher)->GetExperienceMultiplier(); //Student 8/3/2022 applying experience modifier (kb) earlier to apply to repairs
 
             IIgcSite*   pigc = GetMyMission()->GetIgcSite();
             pigc->DamageStationEvent(this, launcher, type, amount);

--- a/src/Igc/stationIGC.cpp
+++ b/src/Igc/stationIGC.cpp
@@ -152,7 +152,7 @@ DamageResult    CstationIGC::ReceiveDamage(DamageTypeID            type,
     {
         float   dtmShield = GetMyMission()->GetDamageConstant(type, m_myStationType.GetShieldDefenseType());
 
-        if (dtmShield != 0.0f)
+        if (dtmShield != 0.0f && m_myStationType.GetMaxShieldHitPoints() != 0.0f) //Student 8/4/2022 explicitly not allow shield damage if maxsdhieldhitpoints == 0
         {
             dr = c_drShieldDamage;
 

--- a/src/Igc/stationIGC.h
+++ b/src/Igc/stationIGC.h
@@ -365,12 +365,19 @@ class       CstationIGC : public TmodelIGC<IstationIGC>
         }
         virtual void    SetShieldFraction(float newVal)
         {
-            if (newVal < 0.0f)
+            if (m_myStationType.GetMaxShieldHitPoints() != 0) //Student 8/4/2022 if there is no shield, m_shieldFraction = 0
+            {
+                if (newVal < 0.0f)
                 newVal = 0.0f;
             else if (newVal > 1.0f)
                 newVal = 1.0f;
 
             m_shieldFraction = newVal;
+            }
+            else
+            {
+                m_shieldFraction = 0.0f;
+            }
         }
 
         virtual bool                    CanBuy(const IbuyableIGC* b) const


### PR DESCRIPTION
Fix errors when bases that have no max shield are captured.
Add kb to asteroids and missiles (previously did not take kb damage)
Apply kb bonus to repair (i.e. nans)

These are all server sided so must be uploaded to the backend.