### PR TITLE
Fix NPE on GetMaxShieldHitPoints

### DIFF
--- a/src/Igc/stationIGC.cpp
+++ b/src/Igc/stationIGC.cpp
@@ -603,7 +603,7 @@ DefenseTypeID        MyStationType::GetArmorDefenseType(void) const
 
 HitPoints            MyStationType::GetMaxShieldHitPoints(void) const
 { 
-    if (m_pstation->GetSide() == NULL) return 1; //Student Note 11/8/2025 if side is null, this object is being destroyed. Because this is now being checked in set shield fraction it caused a NPE
+    if (m_pstation->GetSide() == NULL) return 0; //Student Note 11/8/2025 if side is null, this object is being destroyed. Because this is now being checked in set shield fraction it caused a NPE
     return m_pStationData->maxShieldHitPoints * m_pstation->GetSide()->GetGlobalAttributeSet().GetAttribute(c_gaMaxShieldStation);
 }
 

--- a/src/Igc/stationIGC.cpp
+++ b/src/Igc/stationIGC.cpp
@@ -602,7 +602,8 @@ DefenseTypeID        MyStationType::GetArmorDefenseType(void) const
 }
 
 HitPoints            MyStationType::GetMaxShieldHitPoints(void) const
-{
+{ 
+    if (m_pstation->GetSide() == NULL) return 1; //Student Note 11/8/2025 if side is null, this object is being destroyed. Because this is now being checked in set shield fraction it caused a NPE
     return m_pStationData->maxShieldHitPoints * m_pstation->GetSide()->GetGlobalAttributeSet().GetAttribute(c_gaMaxShieldStation);
 }
 


### PR DESCRIPTION
On destroying a base, there would be a NPE when getting side to check max shield hitpoints (now being checked in setshieldfraction). This is now gracefully covered, preventing a crash.