### PR TITLE
Fix memory leaks and harden network input handling in the game server/lobby

### DIFF
--- a/src/FedSrv/FedSrv.CPP
+++ b/src/FedSrv/FedSrv.CPP
@@ -4836,14 +4836,14 @@ HRESULT FedSrvSiteBase::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxnF
       pMission   = pfsMission->GetIGCMission();
   }
 
-  ttPreHandler.Stop("...for message type %s from %s", g_rgszMsgNames[pfm->fmid],
+  ttPreHandler.Stop("...for message type %s from %s", SafeMsgName(pfm->fmid),
                     pfsPlayer ? pfsPlayer->GetName() : "<unknown>");
 
   if (!pfsPlayer && (pfm->fmid != FM_C_LOGONREQ))
   {
     _AGCModule.TriggerEvent(NULL, AllsrvEventID_MsgFromUnknownPlayer, "", -1, -1, -1, 2,
         "DPNID", VT_I4, cnxnFrom.GetID(), // pkk - Returns DPNID (DirectPlay network identifier)
-        "MsgName", VT_LPSTR, g_rgszMsgNames[pfm->fmid]); // pkk - This should return FedSrvMsgID text, but somehow it doesn't
+        "MsgName", VT_LPSTR, SafeMsgName(pfm->fmid)); // pkk - This should return FedSrvMsgID text, but somehow it doesn't
   }
   else
   switch(pfm->fmid)
@@ -4920,6 +4920,17 @@ HRESULT FedSrvSiteBase::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxnF
 
       TrapHackBoot(pfmChat->cbMessage >= 0);
       TrapHackBoot(pfmChat->ibMessage == sizeof(FMD_CS_CHATMESSAGE));
+
+      // R3 #3 / M5 - The Message var-length field is consumed by _strnicmp/_stricmp/
+      // lstrcpy/lstrcmpi as a NUL-terminated C string below. Confirm the field lies
+      // wholly within the received bytes (ibMessage + cbMessage <= cbmsg) AND that its
+      // last in-bounds byte is '\0' before any string op. cbMessage==0 is allowed (no
+      // string; downstream code NULL-checks FM_VAR_REF/pszMsg). ibMessage and cbMessage
+      // are unsigned short (IB/CB); the (int) cast forces signed arithmetic so the sum
+      // cannot wrap, and the cbMessage==0 short-circuit prevents the -1 underflow.
+      TrapHackBoot(pfmChat->ibMessage + (int)pfmChat->cbMessage <= pfmChat->cbmsg);
+      TrapHackBoot(pfmChat->cbMessage == 0 ||
+                   ((char*)pfmChat)[pfmChat->ibMessage + pfmChat->cbMessage - 1] == '\0');
 
 	  // BT - STEAM - Send the message up to the lobby for logging.
 	  ZString targetName;
@@ -5804,8 +5815,6 @@ HRESULT FedSrvSiteBase::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxnF
 
     case FM_C_LOGONREQ:
     {
-      CQLogonStats * pquery = new CQLogonStats(GotLogonDetails);
-      CQLogonStatsData * pqd = pquery->GetData();
       if (NULL != g.pServerCounters)
         g.pServerCounters->cLoginAttempts++;
 
@@ -5813,13 +5822,16 @@ HRESULT FedSrvSiteBase::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxnF
       char * szReason = "Sorry Charlie. Something \"weird\" happened."; // default failure message
       bool fRetry = false;
 
-      // sanity check the message
+      // sanity check the message (before allocating pquery, so a TrapHackBootNoPlayer break cannot leak it)
       TrapHackBootNoPlayer(NULL != FM_VAR_REF(pfmLogon, CharacterName)
           && NULL != memchr(FM_VAR_REF(pfmLogon, CharacterName), 0, c_cbName));
       TrapHackBootNoPlayer(NULL == FM_VAR_REF(pfmLogon, MissionPassword)
           || NULL != memchr(FM_VAR_REF(pfmLogon, MissionPassword), 0, c_cbGamePassword));
       TrapHackBootNoPlayer(NULL != FM_VAR_REF(pfmLogon, CDKey)
           && NULL != memchr(FM_VAR_REF(pfmLogon, CDKey), 0, c_cbCDKey));
+
+      CQLogonStats * pquery = new CQLogonStats(GotLogonDetails);
+      CQLogonStatsData * pqd = pquery->GetData();
 
       if (pfmLogon->fedsrvVer == MSGVER)
       { // ok, they have the right version of the client
@@ -5946,13 +5958,31 @@ HRESULT FedSrvSiteBase::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxnF
 			// the steam security.
 			&& strcmp(pqd->szCDKey, g.szBotAuthenticationGuid) != 0)
 		{
+			if (pfmLogon->steamAuthTicketLength > sizeof(pqd->steamAuthTicket))
+			{
+				debugf("steam auth ticket length out of range: %u\n", pfmLogon->steamAuthTicketLength);
+
+				pqd->fValid = false;
+				pqd->fRetry = false;
+				Strcpy(pqd->szReason, "Your client sent an invalid Steam authentication ticket. This action has been logged.");
+				PostThreadMessage(g.idReceiveThread, wm_sql_querydone, (WPARAM)NULL, (LPARAM)pquery);
+				break;
+			}
+
 			memcpy(pqd->steamAuthTicket, pfmLogon->steamAuthTicket, pfmLogon->steamAuthTicketLength);
 			pqd->steamAuthTicketLength = pfmLogon->steamAuthTicketLength;
 			pqd->steamID = pfmLogon->steamID;
 
 			CSteamValidation *steamValidation = new CSteamValidation(g.idReceiveThread, pqd->characterID, pquery, pqd);
 			DWORD threadID;
-			CreateThread(NULL, 0, LogonThread, steamValidation, 0, &threadID);
+			HANDLE hLogonThread = CreateThread(NULL, 0, LogonThread, steamValidation, 0, &threadID);
+			if (hLogonThread != NULL)
+			{
+				// LogonThread is fire-and-forget (it deletes steamValidation itself and posts wm_sql_querydone
+				// to dispose pquery); closing the handle now does not stop the thread, it just releases the
+				// kernel handle so it is not leaked once the thread eventually exits.
+				CloseHandle(hLogonThread);
+			}
 		}
 		else
 		{
@@ -6006,6 +6036,13 @@ HRESULT FedSrvSiteBase::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxnF
 
 				PostThreadMessage(g.idReceiveThread, wm_sql_querydone, (WPARAM)NULL, (LPARAM)logonDetailsQuery);
 			}
+
+#if defined(ALLSRV_STANDALONE)
+			// This (non-Steam / bot / steam-auth-disabled) path never hands pquery to CSteamValidation and,
+			// in ALLSRV_STANDALONE builds, the g.sql.PostQuery(pquery) call below is compiled out, so dispose pquery here.
+			delete pquery;
+			pquery = NULL;
+#endif
 		}
 
 		//DWORD threadID;
@@ -6050,6 +6087,10 @@ HRESULT FedSrvSiteBase::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxnF
       } // if correct messaging version
       else
       {
+        // client version mismatch: the version-ok block above (which owns/disposes pquery) was skipped, so free it here to avoid a leak.
+        delete pquery;
+        pquery = NULL;
+
         if (NULL != g.pServerCounters)
           g.pServerCounters->cLoginsFailed++;
         char szVerError[350];
@@ -7821,7 +7862,7 @@ HRESULT FedSrvSiteBase::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxnF
   assert(0 == g.fm.CbUsedSpaceInOutbox());
   //g.fm.SetPriority(c_mcpDefault);
 
-  timerOnAppMessage.Stop("...for message type %s\n", g_rgszMsgNames[pfm->fmid]);
+  timerOnAppMessage.Stop("...for message type %s\n", SafeMsgName(pfm->fmid));
 
   return(S_OK);
 }

--- a/src/FedSrv/fscluster.cpp
+++ b/src/FedSrv/fscluster.cpp
@@ -30,4 +30,17 @@ CFSCluster::CFSCluster(TRef<IclusterIGC> pCluster) :
 CFSCluster::~CFSCluster()
 {
   m_pIclusterIGC->SetPrivateData((DWORD)NULL);  // unlink from IGC CLuster
+
+  // Free the per-cluster dplay groups created in CFSMission::CreateDPGroups.
+  // FedMessaging::DeleteGroup destroys the dplay group and deletes the CFMGroup
+  // object (CFMGroup::Delete -> DestroyGroup + 'delete this'). FedMessaging does
+  // NOT auto-free groups at session teardown (Shutdown() only does
+  // m_groupMap.clear() on a std::map of raw pointers), so this does not double-free.
+  if (m_pClusterGroups)
+  {
+    g.fm.DeleteGroup(m_pClusterGroups->pgrpClusterDocked);
+    g.fm.DeleteGroup(m_pClusterGroups->pgrpClusterFlying);
+    delete m_pClusterGroups;
+    m_pClusterGroups = NULL;
+  }
 }

--- a/src/FedSrv/fslobby.cpp
+++ b/src/FedSrv/fslobby.cpp
@@ -293,7 +293,7 @@ HRESULT FedSrvLobbySite::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxn
     break;
   }
 
-  timerOnAppMessage.Stop("...for message type %s\n", g_rgszMsgNames[pfm->fmid]);
+  timerOnAppMessage.Stop("...for message type %s\n", SafeMsgName(pfm->fmid));
   return hr;
 }
 

--- a/src/FedSrv/fsmission.cpp
+++ b/src/FedSrv/fsmission.cpp
@@ -3916,7 +3916,7 @@ void CFSMission::CreateDPGroups(IclusterIGC * pcluster)
   char szBuff[std::max(sizeof(szDocked), sizeof(szFlying)) + c_cbName + 1];
   wsprintf(szBuff, "%s%s", szDocked, pcluster->GetName());
   pcg->pgrpClusterDocked = g.fm.CreateGroup(szBuff);
-  wsprintf(szBuff, "%s%s", szDocked, pcluster->GetName());
+  wsprintf(szBuff, "%s%s", szFlying, pcluster->GetName());
   pcg->pgrpClusterFlying = g.fm.CreateGroup(szBuff);
 
   ((CFSCluster*)pcluster->GetPrivateData())->SetClusterGroups(pcg);

--- a/src/FedSrv/fsship.cpp
+++ b/src/FedSrv/fsship.cpp
@@ -601,7 +601,8 @@ void CFSShip::CaptureStation(IstationIGC * pstation)
 	  if (IsPlayer())
 	  {
 		  CSteamAchievements *pSteamAchievements = GetPlayer()->GetSteamAchievements();
-		  pSteamAchievements->AwardBaseKillOrCapture(false); //Award Base Capture Achievement
+		  if (pSteamAchievements != NULL)
+			  pSteamAchievements->AwardBaseKillOrCapture(false); //Award Base Capture Achievement
 	  }
 
       for (ShipLinkIGC* psl = GetIGCShip()->GetChildShips()->first();

--- a/src/Inc/messagecore.h
+++ b/src/Inc/messagecore.h
@@ -720,6 +720,18 @@ extern const char * g_rgszMsgNames[];
 #define MAXMESSAGES 400
 #define ALLOC_MSG_LIST const char * g_rgszMsgNames[MAXMESSAGES + 1]
 
+// Safe lookup into g_rgszMsgNames. g_rgszMsgNames has MAXMESSAGES + 1 entries
+// (valid indices 0..MAXMESSAGES). A network-controlled fmid can exceed this range,
+// so callers must NOT index g_rgszMsgNames directly. This helper bounds-checks the
+// id and also returns a placeholder when the slot was never registered (NULL).
+inline const char * SafeMsgName(FEDMSGID fmid)
+{
+  if (fmid > MAXMESSAGES)
+    return "<invalid>";
+  const char * sz = g_rgszMsgNames[fmid];
+  return sz ? sz : "<invalid>";
+}
+
 /*-------------------------------------------------------------------------
  * AddMsg
  *-------------------------------------------------------------------------

--- a/src/_Utility/Messages.cpp
+++ b/src/_Utility/Messages.cpp
@@ -752,6 +752,7 @@ HRESULT FedMessaging::OnSysMessage( const DPlayMsg& msg )
     if ( hr != DPN_OK )
     {
         debugf( "m_pDirectPlayServer->GetClientInfo failed\n");
+        delete[] pPlayerInfo;
         return hr;
     }
 
@@ -1013,10 +1014,20 @@ HRESULT FedMessaging::ReceiveMessages()
 
           int cMsgs = 0;
 #ifndef NO_MSG_CRC
+          // Guard: a network-controlled packet smaller than the CRC trailer (sizeof(int))
+          // would make PacketSize() (= m_dwcbPacket - sizeof(int)) underflow as an unsigned
+          // DWORD to ~4GB, sending MemoryCRC() and the trailer read out of bounds. Reject such packets.
+          if (m_dwcbPacket < sizeof(int))
+          {
+            // Too small to contain a CRC trailer; treat as a bad packet and skip the message walk.
+            m_pfmSite->OnBadCRC(this, *pcnxnFrom, m_rgbbuffInPacket, m_dwcbPacket);
+          }
+          else
+          {
           int crc = MemoryCRC(m_rgbbuffInPacket, PacketSize());
           if (crc == *(int*)(m_rgbbuffInPacket + PacketSize()))
           {
-#endif            
+#endif
             static CTempTimer tt("spent looping through message queue", .1f);
             tt.Start();
             g_fConnectionDeleted = false;
@@ -1026,7 +1037,7 @@ HRESULT FedMessaging::ReceiveMessages()
 
             while (pfm && !g_fConnectionDeleted)
             {
-              if(pfm->fmid > 0 && pfm->cbmsg >= sizeof(FEDMESSAGE) && pfm->cbmsg <= PacketSize())
+              if(pfm->fmid > 0 && pfm->fmid <= MAXMESSAGES && pfm->cbmsg >= sizeof(FEDMESSAGE) && pfm->cbmsg <= PacketSize())
               {
 				 /* if (strcmp(pcnxnFrom->GetName(), "+BackTrak@Dev") == 0)
 				  {
@@ -1062,14 +1073,15 @@ HRESULT FedMessaging::ReceiveMessages()
 #endif
               }
             }
-#ifndef NO_MSG_CRC          
+#ifndef NO_MSG_CRC
           }
           else
           {
             // ACK! Failed CRC. WTF??? ...<sigh> but it happens
             m_pfmSite->OnBadCRC(this, *pcnxnFrom, m_rgbbuffInPacket, m_dwcbPacket);
           }
-#endif          
+          } // close the m_dwcbPacket >= sizeof(int) guard added above
+#endif
         }
         else
         {
@@ -1192,17 +1204,20 @@ bool FedMessaging::KillSvr()
     
     int i = 0;
     const int cRetries = 50; // let's give it 50 retries
-    while (STILL_ACTIVE == exitcode && i > cRetries) 
+    while (STILL_ACTIVE == exitcode && i < cRetries)
     {
       GetExitCodeProcess(pi.hProcess, &exitcode);
       Sleep(100);
       i++;
     }
-    if (i > cRetries)
+    if (STILL_ACTIVE == exitcode)
       fCreated = false;
     else
       debugf("Slept (100ms) %d times  waiting for killsvr\n", i);
     Sleep(1000); // wait another second to make sure it's really gone
+    // CreateProcess opened these handles; close them so they don't leak.
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
   }
   else
   {
@@ -1653,7 +1668,7 @@ HRESULT FedMessaging::GetIPAddress(CFMConnection & cnxn, char szRemoteAddress[64
 {
   //assert( m_pDirectPlayServer != 0 );
 
-  IDirectPlay8Address* pAddress;
+  IDirectPlay8Address* pAddress = NULL;
 
   // WLP 2005 - made this server client and server side
   //
@@ -1670,6 +1685,11 @@ HRESULT FedMessaging::GetIPAddress(CFMConnection & cnxn, char szRemoteAddress[64
 		return E_FAIL;
 	  }
   }
+
+  // If neither path produced an address (e.g. neither server nor client is
+  // active, or the API returned success without setting pAddress), don't deref NULL.
+  if (pAddress == NULL)
+    return E_FAIL;
 
   WCHAR add[200];
   DWORD cnt = 200;

--- a/src/_Utility/allegdb.cpp
+++ b/src/_Utility/allegdb.cpp
@@ -143,6 +143,38 @@ HRESULT CSQLCore::Init(LPCOLESTR strSQLConfig, DWORD nThreadIDNotify, DWORD cSil
 
 CSQLCore::~CSQLCore()
 {
+  // R6: signal ALL sql threads (queue + workers) to exit, and make sure the
+  // queue thread has fully stopped BEFORE we delete its wrapper. The wrapper's
+  // underlying TCThread is auto-deleting (m_bAutoDelete == true): when its
+  // thread proc returns it does 'delete this' and CloseHandle(m_hThread). So we
+  // must grab a stable handle to the queue thread WHILE it is still alive
+  // (before SetEvent), then wait on that handle, and only afterwards delete the
+  // wrapper. m_hKillSQLEvent is a manual-reset event, so a single SetEvent wakes
+  // every waiter and stays signaled.
+  HANDLE hQueueThread = NULL;
+  if (m_pthdQueue && m_hKillSQLEvent)
+  {
+    // Open a private SYNCHRONIZE handle to the still-running queue thread.
+    hQueueThread = OpenThread(SYNCHRONIZE, FALSE, m_pthdQueue->GetThreadID());
+  }
+
+  // Tell every sql thread (queue thread and all worker threads) to exit.
+  if (m_hKillSQLEvent)
+    SetEvent(m_hKillSQLEvent);
+
+  // Wait for the queue thread proc to fully return (which self-deletes its
+  // TCThread) before we touch/delete the wrapper, to avoid a use-after-free.
+  if (hQueueThread)
+  {
+    WaitForSingleObject(hQueueThread, INFINITE);
+    CloseHandle(hQueueThread);
+  }
+
+  // Safe now: the queue thread has exited; the wrapper's implicit destructor
+  // does not touch the (already self-freed) TCThread.
+  delete m_pthdQueue;
+  m_pthdQueue = NULL;
+
   DWORD i = 0;
   for (i = 0; i < m_cNotifyThreads && m_pargNotifyThreads; i++)
   {
@@ -160,6 +192,13 @@ CSQLCore::~CSQLCore()
 
   CloseHandle(m_hQueryNotify);
   CloseHandle(m_hQuerySilent);
+
+  // All threads that waited on the kill event have now been released; close it.
+  if (m_hKillSQLEvent)
+  {
+    CloseHandle(m_hKillSQLEvent);
+    m_hKillSQLEvent = NULL;
+  }
 }
 
 

--- a/src/lobby/client.cpp
+++ b/src/lobby/client.cpp
@@ -235,7 +235,7 @@ HRESULT LobbyClientSite::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxn
   CFLClient * pClient = CFLClient::FromConnection(cnxnFrom);
   assert(pClient);
 
-  debugf("Client: %s from <%s> at time %u\n", g_rgszMsgNames[pfm->fmid], cnxnFrom.GetName(), Time::Now());
+  debugf("Client: %s from <%s> at time %u\n", SafeMsgName(pfm->fmid), cnxnFrom.GetName(), Time::Now());
   
   switch (pfm->fmid)
   {
@@ -265,8 +265,17 @@ HRESULT LobbyClientSite::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxn
 
 	  // BT - STEAM
 	  ZeroMemory(&pqd->steamAuthTicket, sizeof(pqd->steamAuthTicket));
-	  memcpy(pqd->steamAuthTicket, pfmLogon->steamAuthTicket, pfmLogon->steamAuthTicketLength);
-	  pqd->steamAuthTicketLength = pfmLogon->steamAuthTicketLength;
+	  // BT - STEAM - bounds-guard: a hostile/garbage client could send steamAuthTicketLength > sizeof(steamAuthTicket),
+	  // overflowing the fixed 1024-byte destination buffer. Only copy when it fits; otherwise treat the ticket as empty.
+	  if (pfmLogon->steamAuthTicketLength <= sizeof(pqd->steamAuthTicket))
+	  {
+		  memcpy(pqd->steamAuthTicket, pfmLogon->steamAuthTicket, pfmLogon->steamAuthTicketLength);
+		  pqd->steamAuthTicketLength = pfmLogon->steamAuthTicketLength;
+	  }
+	  else
+	  {
+		  pqd->steamAuthTicketLength = 0;
+	  }
 	  pqd->steamID = pfmLogon->steamID;
 
       if (g_pAutoUpdate && pfmLogon->crcFileList != g_pAutoUpdate->GetFileListCRC())

--- a/src/lobby/server.cpp
+++ b/src/lobby/server.cpp
@@ -331,7 +331,7 @@ HRESULT LobbyServerSite::OnAppMessage(FedMessaging * pthis, CFMConnection & cnxn
 		pfmPlayerRankResponse->commandSigma = commandSigma;
 		pfmPlayerRankResponse->commandMu = commandMu;
 		
-		debugf("Client: %s from <%s> at time %u. Rank: %ld\n", g_rgszMsgNames[pfm->fmid], cnxnFrom.GetName(), Time::Now(), pfmPlayerRankResponse->rank);
+		debugf("Client: %s from <%s> at time %u. Rank: %ld\n", SafeMsgName(pfm->fmid), cnxnFrom.GetName(), Time::Now(), pfmPlayerRankResponse->rank);
 
 		pthis->SendMessages(&cnxnFrom, FM_GUARANTEED, FM_FLUSH);
 


### PR DESCRIPTION
## Summary

A static audit of the server-side code (`FedSrv`, the `FedMessaging` transport in `_Utility`, the `lobby`, and IGC-adjacent code) surfaced several network-triggerable safety issues and resource leaks. This PR fixes them with minimal, targeted changes. There are **no wire-format/`MSGVER` changes** — well-formed clients are unaffected.

## Security fixes (network-triggerable, on the logon / message paths)

- **Steam auth ticket overflow** — the logon handlers `memcpy`'d a client-controlled `steamAuthTicketLength` (`uint32`) into a fixed 1024-byte buffer with no bounds check (`FedSrv/FedSrv.CPP`, `lobby/client.cpp`). Oversized lengths are now rejected/clamped before the copy.
- **Out-of-range message id** — `g_rgszMsgNames[fmid]` was indexed by a wire-supplied `fmid` before validation in the server and lobby dispatchers. Added a central `fmid <= MAXMESSAGES` gate in `ReceiveMessages` plus a bounds-checked `SafeMsgName()` helper used at every lookup site.
- **Chat message bounds / NUL-termination** — the chat handler ran `_strnicmp`/`lstrcpy`/etc. on a variable-length field without confirming it lies within the received packet and is NUL-terminated. Added the checks.
- **`PacketSize()` unsigned underflow** — a packet smaller than the CRC trailer made `m_dwcbPacket - sizeof(int)` wrap to ~4 GB, driving an out-of-bounds CRC read. Now guarded.

## Resource / leak fixes

- Free `CQLogonStats` on every early-exit logon path (hack-check, version mismatch, and the `ALLSRV_STANDALONE` bypass path).
- Free the per-cluster `ClusterGroups` (and its two DPlay groups) in `~CFSCluster` — previously leaked once per mission.
- Close the fire-and-forget Steam logon thread handle.
- Signal + join the SQL queue thread and close the kill event in `~CSQLCore`.
- `delete[] pPlayerInfo` on the DPlay create-player error path.
- Initialize/guard `pAddress` in `GetIPAddress`; fix the `KillSvr` wait loop (it never actually waited) and close its process/thread handles.
- Defensive NULL guard in `CFSShip::CaptureStation`.

## Notes

- One audited item — the lobby `szCDKey` copy — was found to be a **non-issue** (it already uses the NULL-safe `Strcpy` wrapper) and was intentionally left unchanged.
- Each change was reviewed for double-free / use-after-free / ordering hazards before being applied.

## Testing

- Builds clean: `AllSrv.exe` and `AllLobby.exe` (`FZDebug|Win32`, v143 toolset).
- Smoke-tested by running the resulting server as a LAN server and connecting a client.
